### PR TITLE
Do not double define @roles

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -1018,11 +1018,7 @@ def restart_services():
                            '{env.environment}?'.format(env=env), default=False):
         utils.abort('Task aborted.')
 
-    @roles(env.supervisor_roles)
-    def _inner():
-        silent_services_restart(use_current_release=True)
-
-    execute(_inner)
+    silent_services_restart(use_current_release=True)
 
 
 def silent_services_restart(use_current_release=False):


### PR DESCRIPTION
@millerdev @biyeun i think this should fix the looping restart services. the `@roles` decorator was defined twice on restart services which i think caused it to execute the restart twice. tried it on staging and it didn't loop. also explains why it worked fine during deploy
