### PR TITLE
Enable keepalive by default

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -13,6 +13,7 @@ base:
   timing_log: null  # make a file path to log deploy timing to it. e.g. '../fabric-timing.txt'
   jython_memory: "3584m"
   formplayer_memory: "3584m"
+  keepalive: 60
 
   # list of servers where the NewRelic app agent should be running
   new_relic_enabled: []


### PR DESCRIPTION
default the keepalive to 60 seconds. the default in fabric is to not use a keepalive which causes zambia to disconnect if a command takes a long time to respond.

buddy @proteusvacuum 
