### PR TITLE
Move old staging machines to use tsung

### DIFF
--- a/fab/inventory/tsung
+++ b/fab/inventory/tsung
@@ -1,0 +1,36 @@
+[proxy]
+hqproxy4.internal.commcarehq.org
+
+[webworkers]
+hqdjango4-staging.internal.commcarehq.org
+hqdjango5-staging.internal.commcarehq.org
+
+[couchdb]
+hqdb0-staging.internal.commcarehq.org
+
+[postgresql]
+hqdb0-staging.internal.commcarehq.org
+
+[rabbitmq]
+hqdb0-staging.internal.commcarehq.org
+
+[zookeeper]
+hqkafka0-staging.internal.commcarehq.org
+
+[kafka]
+hqkafka0-staging.internal.commcarehq.org kafka_broker_id=843
+
+[celery]
+hqdb0-staging.internal.commcarehq.org
+
+[pillowtop]
+hqdb0-staging.internal.commcarehq.org
+
+[redis]
+hqdb0-staging.internal.commcarehq.org
+
+[elasticsearch]
+hqes1-staging.internal.commcarehq.org elasticsearch_node_name=hqes1-tsung
+
+[shared_dir_host]
+hqdb0-staging.internal.commcarehq.org


### PR DESCRIPTION
Doesn't include any touchforms machine (shouldn't be needed for benchmarking) and will install couch to hqdb0

buddy @proteusvacuum 
