### PR TITLE
only run core pillows on prod until reindex is done

### DIFF
--- a/fab/pillows/production.yml
+++ b/fab/pillows/production.yml
@@ -1,30 +1,40 @@
 # fab/pillows/production.yml
 ---
-include_groups:
+#include_groups:
+#  - mvp_indicators
+#include_pillows:
+#  - custom.bihar.models.CareBiharFluffPillow
+#  - custom.opm.models.OpmUserFluffPillow
+#  - custom.apps.cvsu.models.UnicefMalawiFluffPillow
+#  - custom.reports.mc.models.MalariaConsortiumFluffPillow
+#  - custom.m4change.models.AncHmisCaseFluffPillow
+#  - custom.m4change.models.LdHmisCaseFluffPillow
+#  - custom.m4change.models.ImmunizationHmisCaseFluffPillow
+#  - custom.m4change.models.ProjectIndicatorsCaseFluffPillow
+#  - custom.m4change.models.McctMonthlyAggregateFormFluffPillow
+#  - custom.m4change.models.AllHmisCaseFluffPillow
+#  - custom.intrahealth.models.CouvertureFluffPillow
+#  - custom.intrahealth.models.TauxDeSatisfactionFluffPillow
+#  - custom.intrahealth.models.IntraHealthFluffPillow
+#  - custom.intrahealth.models.RecapPassageFluffPillow
+#  - custom.intrahealth.models.TauxDeRuptureFluffPillow
+#  - custom.intrahealth.models.LivraisonFluffPillow
+#  - custom.intrahealth.models.RecouvrementFluffPillow
+#  - custom.care_pathways.models.GeographyFluffPillow
+#  - custom.care_pathways.models.FarmerRecordFluffPillow
+#  - custom.world_vision.models.WorldVisionMotherFluffPillow
+#  - custom.world_vision.models.WorldVisionChildFluffPillow
+#  - custom.world_vision.models.WorldVisionHierarchyFluffPillow
+#  - custom.up_nrhm.models.UpNRHMLocationHierarchyFluffPillow
+#  - custom.up_nrhm.models.ASHAFacilitatorsFluffPillow
+#  - custom.succeed.models.UCLAPatientFluffPillow
+
+exclude_groups:
   - mvp_indicators
-include_pillows:
-  - custom.bihar.models.CareBiharFluffPillow
-  - custom.opm.models.OpmUserFluffPillow
-  - custom.apps.cvsu.models.UnicefMalawiFluffPillow
-  - custom.reports.mc.models.MalariaConsortiumFluffPillow
-  - custom.m4change.models.AncHmisCaseFluffPillow
-  - custom.m4change.models.LdHmisCaseFluffPillow
-  - custom.m4change.models.ImmunizationHmisCaseFluffPillow
-  - custom.m4change.models.ProjectIndicatorsCaseFluffPillow
-  - custom.m4change.models.McctMonthlyAggregateFormFluffPillow
-  - custom.m4change.models.AllHmisCaseFluffPillow
-  - custom.intrahealth.models.CouvertureFluffPillow
-  - custom.intrahealth.models.TauxDeSatisfactionFluffPillow
-  - custom.intrahealth.models.IntraHealthFluffPillow
-  - custom.intrahealth.models.RecapPassageFluffPillow
-  - custom.intrahealth.models.TauxDeRuptureFluffPillow
-  - custom.intrahealth.models.LivraisonFluffPillow
-  - custom.intrahealth.models.RecouvrementFluffPillow
-  - custom.care_pathways.models.GeographyFluffPillow
-  - custom.care_pathways.models.FarmerRecordFluffPillow
-  - custom.world_vision.models.WorldVisionMotherFluffPillow
-  - custom.world_vision.models.WorldVisionChildFluffPillow
-  - custom.world_vision.models.WorldVisionHierarchyFluffPillow
-  - custom.up_nrhm.models.UpNRHMLocationHierarchyFluffPillow
-  - custom.up_nrhm.models.ASHAFacilitatorsFluffPillow
-  - custom.succeed.models.UCLAPatientFluffPillow
+  - fluff
+exclude_pillows:
+  - corehq.pillows.reportcase.ReportCasePillow
+  - corehq.pillows.reportxform.ReportXFormPillow
+  - SqlXFormToElasticsearchPillow
+  - SqlCaseToElasticsearchPillow
+  - CaseSearchToElasticsearchPillow


### PR DESCRIPTION
@czue 

one option to reduce memory usage on pillowtop machine while indexing is in progress
