### PR TITLE
Revert "Set elasticsearch node zones"

### DIFF
--- a/fab/inventory/production
+++ b/fab/inventory/production
@@ -41,10 +41,8 @@ hqtouch1.internal.commcarehq.org
 hqdb0.internal.commcarehq.org
 
 [elasticsearch]
-hqes0.internal-va.commcarehq.org elasticsearch_node_name=hqes0 elasticsearch_node_zone=virginia
-hqes1.internal-va.commcarehq.org elasticsearch_node_name=hqes1 elasticsearch_node_zone=virginia
-hqes2.internal.commcarehq.org elasticsearch_node_name=hqes2 elasticsearch_node_zone=chicago
-hqes3.internal.commcarehq.org elasticsearch_node_name=hqes3 elasticsearch_node_zone=chicago
+hqes2.internal.commcarehq.org elasticsearch_node_name=hqes2
+hqes3.internal.commcarehq.org elasticsearch_node_name=hqes3
 
 [shared_dir_host]
 hqdb0.internal.commcarehq.org


### PR DESCRIPTION
Reverts dimagi/commcare-hq-deploy#43
@dannyroberts 
This will make it difficult to deploy, as it'll try to connect to virginia.  Given that, I think I'm gonna use a branch called `prod-migration` which includes the new machines as I add them, and then not merge it back in until we flip the web workers.
