### PR TITLE
Resume deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 fab/config.py
+*.pickle

--- a/fab/const.py
+++ b/fab/const.py
@@ -38,3 +38,6 @@ RSYNC_EXCLUDE = (
     '*.example',
     '*.db',
 )
+
+CACHED_DEPLOY_ENV_FILENAME = 'cached_deploy_env.pickle'
+CACHED_DEPLOY_CHECKPOINT_FILENAME = 'cached_deploy_checkpoint.pickle'

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -560,10 +560,16 @@ def awesome_deploy(confirm="yes", resume='no'):
         utils.abort('Deployment aborted.')
 
     if resume == 'yes':
-        env.update(retrieve_cached_deploy_env())
+        try:
+            cached_payload = retrieve_cached_deploy_env()
+            checkpoint_index = retrieve_cached_deploy_checkpoint()
+        except Exception:
+            print red('Unable to resume deploy, please start anew')
+            raise
+        env.update(cached_payload)
         env.resume = True
-        env.checkpoint_index = retrieve_cached_deploy_checkpoint() or 0
-        print magenta('You are about to resume the deploy in {}'.format(env.code_current))
+        env.checkpoint_index = checkpoint_index or 0
+        print magenta('You are about to resume the deploy in {}'.format(env.code_root))
 
     if datetime.datetime.now().isoweekday() == 5:
         warning_message = 'Friday'

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import pickle
 import yaml
 import re
 from getpass import getpass
@@ -8,7 +9,14 @@ from github3 import login
 from fabric.api import execute, env
 from fabric.colors import magenta
 
-from const import PROJECT_ROOT
+from const import (
+    PROJECT_ROOT,
+    CACHED_DEPLOY_CHECKPOINT_FILENAME,
+    CACHED_DEPLOY_ENV_FILENAME,
+)
+
+
+global_github = None
 
 
 def execute_with_timing(fn, *args, **kwargs):
@@ -38,8 +46,6 @@ class DeployMetadata(object):
         self.timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M')
         self._deploy_ref = None
         self._deploy_tag = None
-        self._github = _get_github()
-        self._repo = self._github.repository('dimagi', 'commcare-hq')
         self._max_tags = 100
         self._last_tag = None
         self._code_branch = code_branch
@@ -47,7 +53,9 @@ class DeployMetadata(object):
 
     def tag_commit(self):
         pattern = ".*-{}-.*".format(re.escape(self._environment))
-        for tag in self._repo.tags(self._max_tags):
+        github = _get_github()
+        repo = github.repository('dimagi', 'commcare-hq')
+        for tag in repo.tags(self._max_tags):
             if re.match(pattern, tag.name):
                 self._last_tag = tag.name
                 break
@@ -59,8 +67,8 @@ class DeployMetadata(object):
             ))
         tag_name = "{}-{}-deploy".format(self.timestamp, self._environment)
         msg = "{} deploy at {}".format(self._environment, self.timestamp)
-        user = self._github.me()
-        self._repo.create_tag(
+        user = github.me()
+        repo.create_tag(
             tag=tag_name,
             message=msg,
             sha=self.deploy_ref,
@@ -84,14 +92,25 @@ class DeployMetadata(object):
 
     @property
     def deploy_ref(self):
+        github = _get_github()
+        repo = github.repository('dimagi', 'commcare-hq')
         if self._deploy_ref is None:
             # turn whatever `code_branch` is into a commit hash
-            branch = self._repo.branch(self._code_branch)
+            branch = repo.branch(self._code_branch)
             self._deploy_ref = branch.commit.sha
         return self._deploy_ref
 
 
 def _get_github():
+    """
+    This grabs the dimagi github account and stores the state in a global variable.
+    We do not store it in `env` or `DeployMetadata` so that it's possible to
+    unpickle the `env` object without hitting the recursion limit.
+    """
+    global global_github
+
+    if global_github is not None:
+        return global_github
     try:
         from .config import GITHUB_APIKEY
     except ImportError:
@@ -102,11 +121,38 @@ def _get_github():
         ).format(project_root=PROJECT_ROOT)
         username = raw_input('Github username: ')
         password = getpass('Github password: ')
-        return login(
+        global_github = login(
             username=username,
             password=password,
         )
     else:
-        return login(
+        global_github = login(
             token=GITHUB_APIKEY,
         )
+
+    return global_github
+
+
+def cache_deploy_state(command_index):
+    with open(os.path.join(PROJECT_ROOT, CACHED_DEPLOY_CHECKPOINT_FILENAME), 'w') as f:
+        pickle.dump(command_index, f)
+    with open(os.path.join(PROJECT_ROOT, CACHED_DEPLOY_ENV_FILENAME), 'w') as f:
+        pickle.dump(env, f)
+
+
+def retrieve_cached_deploy_env():
+    filename = os.path.join(PROJECT_ROOT, CACHED_DEPLOY_ENV_FILENAME)
+    return _retrieve_cached(filename)
+
+
+def retrieve_cached_deploy_checkpoint():
+    filename = os.path.join(PROJECT_ROOT, CACHED_DEPLOY_CHECKPOINT_FILENAME)
+    return _retrieve_cached(filename)
+
+
+def _retrieve_cached(filename):
+    with open(filename, 'r') as f:
+        try:
+            return pickle.load(f)
+        except Exception:
+            return None

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -140,6 +140,11 @@ def cache_deploy_state(command_index):
         pickle.dump(env, f)
 
 
+def clear_cached_deploy():
+    os.remove(os.path.join(PROJECT_ROOT, CACHED_DEPLOY_CHECKPOINT_FILENAME))
+    os.remove(os.path.join(PROJECT_ROOT, CACHED_DEPLOY_ENV_FILENAME))
+
+
 def retrieve_cached_deploy_env():
     filename = os.path.join(PROJECT_ROOT, CACHED_DEPLOY_ENV_FILENAME)
     return _retrieve_cached(filename)

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -157,7 +157,4 @@ def retrieve_cached_deploy_checkpoint():
 
 def _retrieve_cached(filename):
     with open(filename, 'r') as f:
-        try:
-            return pickle.load(f)
-        except Exception:
-            return None
+        return pickle.load(f)

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -8,8 +8,6 @@ from github3 import login
 from fabric.api import execute, env
 from fabric.colors import magenta
 
-from .const import PROJECT_ROOT
-
 from const import PROJECT_ROOT
 
 


### PR DESCRIPTION
@dannyroberts this gives you the ability to resume deploys if they've crashed. I went with using pickle instead of redis since it's easier to store complex objects with it.
<img width="1551" alt="screen shot 2016-07-01 at 1 35 11 pm" src="https://cloud.githubusercontent.com/assets/918514/16529507/4f5cfdb6-3f91-11e6-9bc2-f6e4dfc01a0d.png">
best read 🐟 but could probably be either since it's fairly small. note this is a PR that goes into https://github.com/dimagi/commcare-hq-deploy/pull/61

cc: @proteusvacuum @sravfeyn 
