### PR TITLE
Use abort exception

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -72,6 +72,7 @@ from utils import execute_with_timing
 if env.ssh_config_path and os.path.isfile(os.path.expanduser(env.ssh_config_path)):
     env.use_ssh_config = True
 
+env.abort_exception = Exception
 env.linewise = True
 env.colorize_errors = True
 env.captain_user = None


### PR DESCRIPTION
@dannyroberts this'll better handle exceptions during deploy. now if a deploy fails during migrate (like a couple days ago) and celery doesn't come back up, the deploy exception handling code which restarts services will handle it correctly.

see here for more documention: http://docs.fabfile.org/en/1.11/usage/env.html#abort-exception

cc: @proteusvacuum @sravfeyn 
