### PR TITLE
Keep until for setup_release

### DIFF
--- a/fab/const.py
+++ b/fab/const.py
@@ -30,6 +30,8 @@ ROLES_PILLOW_RETRY_QUEUE = ['django_monolith', 'pillow_retry_queue']
 ROLES_DB_ONLY = ['pg', 'django_monolith']
 
 RELEASE_RECORD = 'RELEASES.txt'
+KEEP_UNTIL_PREFIX = 'KEEP_UNTIL__'
+DATE_FMT = '%Y-%m-%d_%H.%M'
 
 RSYNC_EXCLUDE = (
     '.DS_Store',

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -359,13 +359,22 @@ def _confirm_translated():
 
 
 @task
-def setup_release():
+def setup_release(keep_days=0):
+    try:
+        keep_days = int(keep_days)
+    except ValueError:
+        print red("Unable to parse '{}' into an integer")
+        exit()
+
     deploy_ref = env.deploy_metadata.deploy_ref  # Make sure we have a valid commit
     execute_with_timing(release.create_code_dir)
     execute_with_timing(release.update_code, deploy_ref)
     execute_with_timing(release.update_virtualenv)
 
     execute_with_timing(copy_release_files)
+
+    if keep_days > 0:
+        execute_with_timing(release.mark_keep_until, keep_days)
 
 
 def conditionally_stop_pillows_and_celery_during_migrate():

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -360,6 +360,17 @@ def _confirm_translated():
 
 @task
 def setup_release(keep_days=0):
+    """
+    Setup a release in the releases directory with the most recent code.
+    Useful for running management commands. These releases will automatically
+    be cleaned up at the finish of each deploy. To ensure that a release will
+    last past a deploy use the `keep_days` param.
+
+    :param keep_days: The number of days to keep this release before it will be purged
+
+    Example:
+    fab <env> setup_release:keep_days=10  # Makes a new release that will last for 10 days
+    """
     try:
         keep_days = int(keep_days)
     except ValueError:

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -363,7 +363,7 @@ def setup_release(keep_days=0):
     try:
         keep_days = int(keep_days)
     except ValueError:
-        print red("Unable to parse '{}' into an integer")
+        print red("Unable to parse '{}' into an integer".format(keep_days))
         exit()
 
     deploy_ref = env.deploy_metadata.deploy_ref  # Make sure we have a valid commit

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -13,6 +13,7 @@ from const import (
     PROJECT_ROOT,
     CACHED_DEPLOY_CHECKPOINT_FILENAME,
     CACHED_DEPLOY_ENV_FILENAME,
+    DATE_FMT,
 )
 
 
@@ -43,7 +44,7 @@ def get_pillow_env_config(environment):
 
 class DeployMetadata(object):
     def __init__(self, code_branch, environment):
-        self.timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M')
+        self.timestamp = datetime.datetime.utcnow().strftime(DATE_FMT)
         self._deploy_ref = None
         self._deploy_tag = None
         self._max_tags = 100


### PR DESCRIPTION
@esoergel this was pretty fun. it'll allow you to keep a `setup_release` for a specified amount of days. so if you run `fab staging setup_release:keep_days=10` it'll keep the release around for 10 days before deleting it. good suggestion! (label on because i want to wait to get refactor-operations-2 in)

cc: @proteusvacuum @sravfeyn 
