### PR TITLE
add exception message to deploy failures

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -332,7 +332,7 @@ def hotfix_deploy():
     run('echo ping!')  # workaround for delayed console response
     try:
         execute(release.update_code, env.deploy_metadata.deploy_ref, True)
-    except Exception, e:
+    except Exception as e:
         execute(mail_admins, "Deploy failed", u"Exception message:\n{exc}".format(exc=e))
         # hopefully bring the server back to life
         silent_services_restart(use_current_release=True)
@@ -435,7 +435,7 @@ def _deploy_without_asking():
              "and wait for an email saying it's done. "
              "Thank you for using AWESOME DEPLOY.")
         )
-    except Exception, e:
+    except Exception as e:
         execute_with_timing(
             mail_admins,
             "Deploy to {} failed".format(env.environment),

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -332,8 +332,8 @@ def hotfix_deploy():
     run('echo ping!')  # workaround for delayed console response
     try:
         execute(release.update_code, env.deploy_metadata.deploy_ref, True)
-    except Exception:
-        execute(mail_admins, "Deploy failed", "You had better check the logs.")
+    except Exception, e:
+        execute(mail_admins, "Deploy failed", u"Exception message:\n{exc}".format(exc=e))
         # hopefully bring the server back to life
         silent_services_restart(use_current_release=True)
         raise
@@ -435,11 +435,11 @@ def _deploy_without_asking():
              "and wait for an email saying it's done. "
              "Thank you for using AWESOME DEPLOY.")
         )
-    except Exception:
+    except Exception, e:
         execute_with_timing(
             mail_admins,
             "Deploy to {} failed".format(env.environment),
-            "You had better check the logs."
+            u"Exception message:\n{exc}".format(exc=e)
         )
         # hopefully bring the server back to life
         silent_services_restart()

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -431,7 +431,6 @@ def _deploy_without_asking():
     ]
 
     try:
-        raise Exception
         for index, command in enumerate(commands):
             deploy_checkpoint(index, command.func_name, execute_with_timing, command)
     except PreindexNotFinished:

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 import pickle
+import sys
+import traceback
 import yaml
 import re
 from getpass import getpass
@@ -159,3 +161,9 @@ def retrieve_cached_deploy_checkpoint():
 def _retrieve_cached(filename):
     with open(filename, 'r') as f:
         return pickle.load(f)
+
+
+def traceback_string():
+    exc_type, exc, tb = sys.exc_info()
+    trace = "".join(traceback.format_tb(tb))
+    return u"Exception: {exc}\n Traceback:\n{trace}".format(exc=exc, t=trace)


### PR DESCRIPTION
Here's a proposal. Presently staging deploy doesn't get as much love and it mostly fails. The failure info and the debug info is usually only with the dev whoever successfully deploys the staging (I am assuming we don't log the deploy exceptions anywhere else). If we treat these failures like 500 emails, we can try to incrementally fix these since we don't resource fixing staging. We will get more visibility into deploy failures and their respective fixes so that someone like me can have these as resources while debugging deploying. 
