### PR TITLE
Download formplayer jar to build repo

### DIFF
--- a/fab/const.py
+++ b/fab/const.py
@@ -43,3 +43,5 @@ RSYNC_EXCLUDE = (
 
 CACHED_DEPLOY_ENV_FILENAME = 'cached_deploy_env.pickle'
 CACHED_DEPLOY_CHECKPOINT_FILENAME = 'cached_deploy_checkpoint.pickle'
+
+FORMPLAYER_BUILD_DIR = 'formplayer_build'

--- a/fab/operations/formplayer.py
+++ b/fab/operations/formplayer.py
@@ -13,7 +13,7 @@ def build_formplayer():
     if not files.exists(new_build_dir):
         sudo('mkdir {}'.format(new_build_dir))
 
-    jenkins_formplayer_build_url = 'http://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
+    jenkins_formplayer_build_url = 'https://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
 
     sudo('wget {} -P {}'.format(jenkins_formplayer_build_url, build_dir))
     sudo('wget {} -P {}'.format(jenkins_formplayer_build_url, new_build_dir))

--- a/fab/operations/formplayer.py
+++ b/fab/operations/formplayer.py
@@ -1,4 +1,7 @@
+import os
+
 from fabric.api import roles, env, sudo
+from fabric.contrib import files
 
 from ..const import ROLES_TOUCHFORMS
 
@@ -6,6 +9,11 @@ from ..const import ROLES_TOUCHFORMS
 @roles(ROLES_TOUCHFORMS)
 def build_formplayer():
     build_dir = '{}/{}'.format(env.code_root, 'submodules/formplayer/build/libs')
+    new_build_dir = os.path.join(env.code_root, 'formplayer_build')
+    if not files.exists(new_build_dir):
+        sudo('mkdir {}'.format(new_build_dir))
+
     jenkins_formplayer_build_url = 'http://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
 
     sudo('wget {} -P {}'.format(jenkins_formplayer_build_url, build_dir))
+    sudo('wget {} -P {}'.format(jenkins_formplayer_build_url, new_build_dir))

--- a/fab/operations/formplayer.py
+++ b/fab/operations/formplayer.py
@@ -15,5 +15,5 @@ def build_formplayer():
 
     jenkins_formplayer_build_url = 'https://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
 
-    sudo('wget {} -P {}'.format(jenkins_formplayer_build_url, build_dir))
-    sudo('wget {} -P {}'.format(jenkins_formplayer_build_url, new_build_dir))
+    sudo('wget -nv {} -P {}'.format(jenkins_formplayer_build_url, build_dir))
+    sudo('wget -nv {} -P {}'.format(jenkins_formplayer_build_url, new_build_dir))

--- a/fab/operations/formplayer.py
+++ b/fab/operations/formplayer.py
@@ -3,13 +3,13 @@ import os
 from fabric.api import roles, env, sudo
 from fabric.contrib import files
 
-from ..const import ROLES_TOUCHFORMS
+from ..const import ROLES_TOUCHFORMS, FORMPLAYER_BUILD_DIR
 
 
 @roles(ROLES_TOUCHFORMS)
 def build_formplayer():
     build_dir = '{}/{}'.format(env.code_root, 'submodules/formplayer/build/libs')
-    new_build_dir = os.path.join(env.code_root, 'formplayer_build')
+    new_build_dir = os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)
     if not files.exists(new_build_dir):
         sudo('mkdir {}'.format(new_build_dir))
 

--- a/fab/operations/release.py
+++ b/fab/operations/release.py
@@ -16,6 +16,7 @@ from ..const import (
     ROLES_STATIC,
     DATE_FMT,
     KEEP_UNTIL_PREFIX,
+    FORMPLAYER_BUILD_DIR,
 )
 
 
@@ -210,6 +211,12 @@ def copy_formplayer_properties():
         '{}/submodules/formplayer/config'.format(
             env.code_current, env.code_root
         ))
+    with settings(warn_only=True):
+        sudo(
+            'cp {} {}'.format(
+                os.path.join(env.code_current, FORMPLAYER_BUILD_DIR, 'application.properties'),
+                os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)
+            ))
 
 
 @parallel


### PR DESCRIPTION
@snopoke this isn't complete or tested, but i realized that since we are downloading the formplayer jar from jenkins it actually makes no difference what the submodule commit is for HQ. i'm thinking about ripping out the formplayer submodule and just downloading the jar to some folder that contains the application props. that seem reasonable?
