### PR TITLE
Make the dir first

### DIFF
--- a/fab/operations/release.py
+++ b/fab/operations/release.py
@@ -211,6 +211,7 @@ def copy_formplayer_properties():
         '{}/submodules/formplayer/config'.format(
             env.code_current, env.code_root
         ))
+    sudo('mkdir -p {}'.format(os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)))
     sudo(
         'cp {} {}'.format(
             os.path.join(env.code_current, FORMPLAYER_BUILD_DIR, 'application.properties'),


### PR DESCRIPTION
@esoergel @wpride this explains a lot... it was copying the app props to the file formplayer_build instead of the directory because the dir didn't exist yet
