### PR TITLE
Deploy formplayer without deploying stack

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -357,6 +357,12 @@ def _confirm_translated():
 
 
 @task
+def deploy_formplayer():
+    execute(formplayer.build_formplayer, True)
+    execute(supervisor.restart_formplayer)
+
+
+@task
 def setup_release(keep_days=0):
     """
     Setup a release in the releases directory with the most recent code.

--- a/fab/operations/formplayer.py
+++ b/fab/operations/formplayer.py
@@ -7,11 +7,12 @@ from ..const import ROLES_TOUCHFORMS, FORMPLAYER_BUILD_DIR
 
 
 @roles(ROLES_TOUCHFORMS)
-def build_formplayer():
-    build_dir = os.path.join(env.code_root, FORMPLAYER_BUILD_DIR)
+def build_formplayer(use_current_release=False):
+    code_dir = env.code_root if not use_current_release else env.code_current
+    build_dir = os.path.join(code_dir, FORMPLAYER_BUILD_DIR)
     if not files.exists(build_dir):
         sudo('mkdir {}'.format(build_dir))
 
     jenkins_formplayer_build_url = 'https://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
 
-    sudo('wget -nv {} -P {}'.format(jenkins_formplayer_build_url, build_dir))
+    sudo('wget -nv {} -O {}/formplayer.jar'.format(jenkins_formplayer_build_url, build_dir))

--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -254,6 +254,9 @@ def restart_all_except_webworkers():
 def restart_webworkers():
     _services_restart()
 
+@roles(ROLES_TOUCHFORMS)
+def restart_formplayer():
+    _services_restart()
 
 def _services_restart():
     """Stop and restart all supervisord services"""


### PR DESCRIPTION
@wpride @dannyroberts this'll make it easy to quickly deploy formplayer without having to deploy the rest of the stack 
