### PR TITLE
validate checkpoints on deploy

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -87,6 +87,11 @@ if not hasattr(env, 'code_branch'):
            "You can set it with '--set code_branch=<branch>'")
     env.code_branch = 'master'
 
+
+if not hasattr(env, 'force'):
+    env.force = False  # --set force=true to override blocking warnings (e.g. stale pillow checkpoints)
+
+
 env.roledefs = {
     'django_celery': [],
     'django_app': [],
@@ -422,6 +427,7 @@ def _deploy_without_asking():
         staticfiles.prime_version_static,
         db.ensure_preindex_completion,
         # handle static files
+        db.ensure_checkpoints_safe,
         staticfiles.version_static,
         staticfiles.bower_install,
         staticfiles.npm_install,

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -427,7 +427,6 @@ def _deploy_without_asking():
         # Compute version statics while waiting for preindex
         staticfiles.prime_version_static,
         db.ensure_preindex_completion,
-        # handle static files
         db.ensure_checkpoints_safe,
         staticfiles.version_static,
         staticfiles.bower_install,

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -207,6 +207,7 @@ def staging():
         print ("using default branch of autostaging. you can override this "
                "with --set code_branch=<branch>")
 
+    env.force = True  # don't worry about kafka checkpoints on staging
     env.inventory = os.path.join(PROJECT_ROOT, 'inventory', 'staging')
     load_env('staging')
     execute(env_common)

--- a/fab/operations/db.py
+++ b/fab/operations/db.py
@@ -42,6 +42,15 @@ def ensure_preindex_completion():
 
 
 @roles(ROLES_DB_ONLY)
+def ensure_checkpoints_safe():
+    extras = '--print-only' if env.force else ''
+    with cd(env.code_root):
+        sudo('{env.virtualenv_root}/bin/python manage.py validate_kafka_pillow_checkpoints {extras}'.format(
+            env=env, extras=extras
+        ))
+
+
+@roles(ROLES_DB_ONLY)
 def _is_preindex_complete():
     with settings(warn_only=True):
         return sudo(

--- a/fab/operations/db.py
+++ b/fab/operations/db.py
@@ -45,9 +45,21 @@ def ensure_preindex_completion():
 def ensure_checkpoints_safe():
     extras = '--print-only' if env.force else ''
     with cd(env.code_root):
-        sudo('{env.virtualenv_root}/bin/python manage.py validate_kafka_pillow_checkpoints {extras}'.format(
-            env=env, extras=extras
-        ))
+        try:
+            sudo('{env.virtualenv_root}/bin/python manage.py validate_kafka_pillow_checkpoints {extras}'.format(
+                env=env, extras=extras
+            ))
+        except Exception as e:
+            if not env.force:
+                message = (
+                    "Deploy failed, likely because kafka checkpoints weren't avaialable.\n"
+                    "Scroll up for more detailed information.\n"
+                    "You can rerun with --force=true to prevent this error from blocking the deploy."
+                ).format(e)
+                raise Exception(message)
+            else:
+                # if we were forcing and still got an error this is likely a bug so we should raise it
+                raise
 
 
 @roles(ROLES_DB_ONLY)

--- a/fab/operations/db.py
+++ b/fab/operations/db.py
@@ -52,7 +52,7 @@ def ensure_checkpoints_safe():
         except Exception as e:
             if not env.force:
                 message = (
-                    "Deploy failed, likely because kafka checkpoints weren't avaialable.\n"
+                    "Deploy failed, likely because kafka checkpoints weren't available.\n"
                     "Scroll up for more detailed information.\n"
                     "You can rerun with --force=true to prevent this error from blocking the deploy."
                 ).format(e)


### PR DESCRIPTION
@benrudolph @snopoke this causes deploy to fail if checkpoints are not available in the kafka feed.

also allows you to pass `--set force=true` to bypass this.
