### PR TITLE
single quotes instead of back ticks

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -455,7 +455,7 @@ def _deploy_without_asking():
     except Exception:
         execute_with_timing(
             mail_admins,
-            "Deploy to {environment} failed. Try resuming with `fab {environment} deploy:resume=yes`.".format(environment=env.environment),
+            "Deploy to {environment} failed. Try resuming with 'fab {environment} deploy:resume=yes'.".format(environment=env.environment),
             traceback_string()
         )
         # hopefully bring the server back to life


### PR DESCRIPTION
@czue was hoping that slack would format it correctly, but turns out it's just blank 😞 
