### PR TITLE
Decommission hqriak3 on prod

### DIFF
--- a/fab/inventory/production
+++ b/fab/inventory/production
@@ -54,7 +54,6 @@ datadisk_device=/dev/xvde
 hqriak0.internal-va.commcarehq.org
 hqriak1.internal-va.commcarehq.org
 hqriak2.internal-va.commcarehq.org
-hqriak3.internal-va.commcarehq.org
 hqriak4.internal-va.commcarehq.org
 hqriak5.internal-va.commcarehq.org
 hqriak6.internal-va.commcarehq.org


### PR DESCRIPTION
Arbitrarily chose hqriak3 to be removed to reduce our cluster size to 6 nodes.

@dannyroberts cc @esoergel 
