### PR TITLE
No downtime web worker restart

### DIFF
--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -284,7 +284,7 @@ def restart_all_except_webworkers():
 def _decommission_host(host):
     files.comment(
         '/etc/nginx/sites-available/{}_commcare'.format(env.environment),
-        '^[ ]*server {}'.format(host),
+        '^[ ]*server[ ]+{}'.format(host),
         use_sudo=True,
     )
     _check_and_reload_nginx()
@@ -294,7 +294,7 @@ def _decommission_host(host):
 def _recommission_host(host):
     files.uncomment(
         '/etc/nginx/sites-available/{}_commcare'.format(env.environment),
-        host,
+        'server[ ]+{}'.format(host),
         use_sudo=True,
     )
     _check_and_reload_nginx()

--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -307,13 +307,13 @@ def _check_and_reload_nginx():
 
 @contextmanager
 def decommissioned_host(host):
-    is_monolith = len(env.roledefs['django_app']) > 1
-    if is_monolith:
+    not_monolith = len(env.roledefs['django_app']) > 1
+    if not_monolith:
         execute(_decommission_host, host)
 
     yield
 
-    if is_monolith:
+    if not_monolith:
         execute(_recommission_host, host)
 
 


### PR DESCRIPTION
@dannyroberts this is an idea for having a no downtime web worker restart. we still experience a blip in service every time we restart. i believe this is because nginx still serves requests to the server until it realizes it's down. this would decommission the node until the restart has finished (only for clusters). we would also need to allow the `cchq` user to reload the nginx config. hasn't been tested at all, just felt inspired
