### PR TITLE
Try autoscale on a subset of celery workers

### DIFF
--- a/fab/services/templates/supervisor_celery_async_restore_queue.conf
+++ b/fab/services/templates/supervisor_celery_async_restore_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_async_restore_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=async_restore_queue --events --loglevel=INFO --hostname={{ host_string }}_async_restore_queue --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=async_restore_queue --events --loglevel=INFO --hostname={{ host_string }}_async_restore_queue --maxtasksperchild=50 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_email_queue.conf
+++ b/fab/services/templates/supervisor_celery_email_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_email_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=email_queue --events --loglevel=INFO --hostname={{ host_string }}_email_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=email_queue --events --loglevel=INFO --hostname={{ host_string }}_email_queue --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_logistics_reminder_queue.conf
+++ b/fab/services/templates/supervisor_celery_logistics_reminder_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_logistics_reminder_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=logistics_reminder_queue --events --loglevel=INFO --hostname={{ host_string }}_logistics_reminder_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=logistics_reminder_queue --events --loglevel=INFO --hostname={{ host_string }}_logistics_reminder_queue --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_pillow_retry_queue.conf
+++ b/fab/services/templates/supervisor_celery_pillow_retry_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_pillow_retry_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=pillow_retry_queue --events --loglevel=INFO --hostname={{ host_string }}_pillow_retry_queue --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=pillow_retry_queue --events --loglevel=INFO --hostname={{ host_string }}_pillow_retry_queue --maxtasksperchild=50 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_reminder_rule_queue.conf
+++ b/fab/services/templates/supervisor_celery_reminder_rule_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_reminder_rule_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=reminder_rule_queue --events --loglevel=INFO --hostname={{ host_string }}_reminder_rule_queue --maxtasksperchild=1 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=reminder_rule_queue --events --loglevel=INFO --hostname={{ host_string }}_reminder_rule_queue --maxtasksperchild=1 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_saved_exports_queue.conf
+++ b/fab/services/templates/supervisor_celery_saved_exports_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_saved_exports_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=saved_exports_queue --events --loglevel=INFO --hostname={{ host_string }}_saved_exports_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=saved_exports_queue --events --loglevel=INFO --hostname={{ host_string }}_saved_exports_queue --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_ucr_queue.conf
+++ b/fab/services/templates/supervisor_celery_ucr_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_ucr_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=ucr_queue --events --loglevel=INFO --hostname={{ host_string }}_ucr_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=ucr_queue --events --loglevel=INFO --hostname={{ host_string }}_ucr_queue --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1


### PR DESCRIPTION
@dannyroberts @benrudolph 

I tested this locally and it seems to work as expected. What this does is, for a worker with a concurrency of 4 for example, instead of having 1 parent worker process and 4 child worker processes running, when there are no tasks being executed it will scale down to just 1 parent worker process and 0 child worker processes, freeing up memory.

I figured we could try this out with some of the lower priority workers first, and if all goes well then we can move all of them to use this.

So when all of these workers in this PR are idle or have little work, we're saving up to 7 processes on celery0 and 10 on celery1.
