### PR TITLE
Revert "Decommission hqriak3 on prod"

### DIFF
--- a/fab/inventory/production
+++ b/fab/inventory/production
@@ -57,6 +57,7 @@ datadisk_device=/dev/xvde
 hqriak0.internal-va.commcarehq.org
 hqriak1.internal-va.commcarehq.org
 hqriak2.internal-va.commcarehq.org
+hqriak3.internal-va.commcarehq.org
 hqriak4.internal-va.commcarehq.org
 hqriak5.internal-va.commcarehq.org
 hqriak6.internal-va.commcarehq.org


### PR DESCRIPTION
Re-adding hqriak3 because running out of disk space in Riak CS cluster.

@dannyroberts cc @NoahCarnahan 
