### PR TITLE
Move case update worker to celery1

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -62,8 +62,6 @@ production:
         concurrency: 4
       pillow_retry_queue:
         concurrency: 1
-      reminder_case_update_queue:
-        concurrency: 4
       email_queue:
         concurrency: 2
       repeat_record_queue:
@@ -71,6 +69,8 @@ production:
       ucr_queue:
         concurrency: 4
     hqcelery1:
+      reminder_case_update_queue:
+        concurrency: 4
       reminder_queue:
         concurrency: 8
       reminder_rule_queue:


### PR DESCRIPTION
@benrudolph 
celery0 seems to have higher memory usage than celery1, and i've also seen some higher spikes in celery0's memory usage (one time i saw the main worker was taking up 50% of the memory on the machine). this will hopefully help even out the memory usage between the machines.
