### PR TITLE
Revert "Revert "Bash controlled celery""

### DIFF
--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -61,7 +61,7 @@ def _get_celery_queues():
 def set_celery_supervisorconf():
 
     conf_files = {
-        'main':                         ['supervisor_celery_main.conf'],
+        'main':                         ['supervisor_celery_main.conf', 'celery_main_bash.sh'],
         'periodic':                     ['supervisor_celery_beat.conf', 'supervisor_celery_periodic.conf'],
         'sms_queue':                    ['supervisor_celery_sms_queue.conf'],
         'reminder_queue':               ['supervisor_celery_reminder_queue.conf'],

--- a/fab/services/templates/celery_main_bash.sh
+++ b/fab/services/templates/celery_main_bash.sh
@@ -1,0 +1,21 @@
+# Catch any TERM or INT signals and propagate
+# to the Celery process. Upon catching of the signal
+# the 'wait' command below will terminate and thus will
+# exit the bash process.
+#
+# > When Bash is waiting for an asynchronous command via the wait
+# > built-in, the reception of a signal for which a trap has
+# > been set will cause the wait built-in to return immediately
+# > with an exit status greater than 128, immediately after which
+# > the trap is executed.
+#
+# See Section 12.2.2 of http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_12_02.html
+#
+# Effectively we've no orphaned
+# the Celery process to do a warm shutdown and we are
+# free to start another bash process under supervisor.
+trap 'kill -TERM $PID' TERM INT
+TIMESTAMP=`date +%s`
+{{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=celery --events --loglevel=INFO --hostname={{ host_string }}_main.${TIMESTAMP}_timestamp --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair &
+PID=$!
+wait $PID

--- a/fab/services/templates/celery_main_bash.sh
+++ b/fab/services/templates/celery_main_bash.sh
@@ -11,7 +11,7 @@
 #
 # See Section 12.2.2 of http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_12_02.html
 #
-# Effectively we've no orphaned
+# Effectively we've orphaned
 # the Celery process to do a warm shutdown and we are
 # free to start another bash process under supervisor.
 trap 'kill -TERM $PID' TERM INT

--- a/fab/services/templates/supervisor_celery_main.conf
+++ b/fab/services/templates/supervisor_celery_main.conf
@@ -1,13 +1,13 @@
 [program:{{ project }}-{{ environment }}-celery_main]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=celery --events --loglevel=INFO --hostname={{ host_string }}_main --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair
+command=/bin/bash {{ code_current }}/services/supervisor/{{ environment }}_celery_main_bash.sh
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1
 autostart=true
 autorestart=true
-stopasgroup=true
-killasgroup=true
+stopasgroup=false
+killasgroup=false
 stdout_logfile={{ log_dir }}/celery_main.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/celery_main.error.log


### PR DESCRIPTION
Reverts dimagi/commcare-hq-deploy#122

@benrudolph when this was deployed the main worker didn't start because it was looking for `production_celery_main_bash.sh` that didn't exist (no *.sh file was copied into the services directory)

there's no rush on this, figured we'd just revert and you can have a look whenever you have time
