### PR TITLE
Remove celery flower from blacklist

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -115,7 +115,6 @@ swiss:
 
   service_blacklist:
     - supervisor_websockets.conf
-    - supervisor_celery_flower.conf
     - supervisor_formplayer_spring.conf
 
   celery_processes:


### PR DESCRIPTION
@nickpell this'll have flower run on swiss again. makes sense to add back in since we depend on it for our celery worker checks

http://manage.dimagi.com/default.asp?238637
