### PR TITLE
adding db0 as india standby to get newest backup script

### DIFF
--- a/fab/inventory/softlayer
+++ b/fab/inventory/softlayer
@@ -93,3 +93,6 @@ datavol_device=/dev/xvdc
 
 [stanchion:children]
 riak5
+
+[pg_standby:children]
+db0


### PR DESCRIPTION
@gcapalbo 
All the backup work is in the standby task now, so we need to designate the main db machine as the standby one to get the latest chagnes
