### PR TITLE
Add swap to riakcs hosts

### DIFF
--- a/fab/inventory/production
+++ b/fab/inventory/production
@@ -65,6 +65,7 @@ hqriak7.internal-va.commcarehq.org
 
 [riakcs:vars]
 datavol_device=/dev/xvdb
+swap_size=4G
 
 [stanchion]
 hqriak0.internal-va.commcarehq.org


### PR DESCRIPTION
Riak has been running well since I added swap during the dev summit. No OOM crashes and no noticeable performance hit since an initial period of slowness just after enabling swap. Maybe riak's memory usage patterns paired with our sparsely accessed data set actually works well with swap? If so it's a cheap way to feed a memory hungry beast.

Ansible PR coming up next.

@snopoke @czue cc @kaapstorm @proteusvacuum 
