### PR TITLE
Add kill stale workers

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -359,6 +359,14 @@ def _confirm_translated():
 
 
 @task
+def kill_stale_celery_workers():
+    """
+    Kills celery workers that failed to properly go into warm shutdown
+    """
+    execute(release.kill_stale_celery_workers)
+
+
+@task
 def deploy_formplayer():
     execute(formplayer.build_formplayer, True)
     execute(supervisor.restart_formplayer)
@@ -451,6 +459,7 @@ def _deploy_without_asking():
         db.flip_es_aliases,
         staticfiles.update_manifest,
         release.clean_releases,
+        release.kill_stale_celery_workers,
     ]
 
     try:

--- a/fab/operations/release.py
+++ b/fab/operations/release.py
@@ -103,6 +103,14 @@ def create_code_dir():
 
 
 @roles(ROLES_DB_ONLY)
+def kill_stale_celery_workers():
+    with cd(env.code_current):
+        sudo(
+            '{}/bin/python manage.py kill_stale_celery_workers'.format(env.virtualenv_current)
+        )
+
+
+@roles(ROLES_DB_ONLY)
 def record_successful_deploy():
     start_time = datetime.strptime(env.deploy_metadata.timestamp, DATE_FMT)
     delta = datetime.utcnow() - start_time


### PR DESCRIPTION
@gcapalbo this should mitigate our issues we've been seeing around random celery workers continuing to exist. tested it on prod and staging and it worked. it shouldn't interfere with workers that have properly engaged in a warm shutdown

cc: @emord @nickpell 
