### PR TITLE
Remove delay kill celery workers

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -678,7 +678,6 @@ def silent_services_restart(use_current_release=False):
     execute(db.set_in_progress_flag, use_current_release)
     execute(supervisor.restart_all_except_webworkers)
     execute(supervisor.restart_webworkers)
-    execute(release.delay_kill_stale_celery_workers)
 
 
 @task

--- a/fab/operations/release.py
+++ b/fab/operations/release.py
@@ -113,11 +113,6 @@ def kill_stale_celery_workers(delay=0):
 
 
 @roles(ROLES_DB_ONLY)
-def delay_kill_stale_celery_workers():
-    kill_stale_celery_workers(delay=1)
-
-
-@roles(ROLES_DB_ONLY)
 def record_successful_deploy():
     start_time = datetime.strptime(env.deploy_metadata.timestamp, DATE_FMT)
     delta = datetime.utcnow() - start_time


### PR DESCRIPTION
@gcapalbo i received no soft asserts since moving to the new way of killing the celery workers, so i think we may have finally won the war on this.

i searched my inbox and there has only been 2 worker exited early due to SIGTERM for the main queue since we switched to `_timestamp`ed workers (circa Oct 5th). i'm pretty sure those were due to us manually killing the queue. this also means we should officially have a no downtime deploy (though users may experience some slowness) 🎉 level unlocked

keeping kill_stale_workers around just in case

cc: @mkangia 