### PR TITLE
only run certain command once per deploy

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -36,6 +36,7 @@ from fabric.api import run, roles, execute, task, sudo, env, parallel
 from fabric.colors import blue, red, magenta
 from fabric.context_managers import cd
 from fabric.contrib import files, console
+from fabric.decorators import runs_once
 from fabric.operations import require
 from const import (
     ROLES_ALL_SRC,
@@ -312,6 +313,7 @@ def preindex_views():
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def mail_admins(subject, message):
     with cd(env.code_root):
         sudo((

--- a/fab/operations/db.py
+++ b/fab/operations/db.py
@@ -3,12 +3,14 @@ import time
 
 from fabric.context_managers import cd, settings
 from fabric.api import roles, sudo, env, parallel
+from fabric.decorators import runs_once
 
 from ..exceptions import PreindexNotFinished
 from ..const import ROLES_DB_ONLY, ROLES_PILLOWTOP
 
 
 @roles(ROLES_PILLOWTOP)
+@runs_once
 def preindex_views():
     with cd(env.code_root):
         sudo((
@@ -42,6 +44,7 @@ def ensure_preindex_completion():
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def ensure_checkpoints_safe():
     extras = '--print-only' if env.force else ''
     with cd(env.code_root):
@@ -63,6 +66,7 @@ def ensure_checkpoints_safe():
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def _is_preindex_complete():
     with settings(warn_only=True):
         return sudo(
@@ -78,6 +82,7 @@ def _is_preindex_complete():
 
 @roles(ROLES_DB_ONLY)
 @parallel
+@runs_once
 def flip_es_aliases():
     """Flip elasticsearch aliases to the latest version"""
     with cd(env.code_root):
@@ -85,6 +90,7 @@ def flip_es_aliases():
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def migrate():
     """run migrations on remote environment"""
     with cd(env.code_root):
@@ -93,6 +99,7 @@ def migrate():
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def set_in_progress_flag(use_current_release=False):
     venv = env.virtualenv_root if not use_current_release else env.virtualenv_current
     with cd(env.code_root if not use_current_release else env.code_current):
@@ -100,6 +107,7 @@ def set_in_progress_flag(use_current_release=False):
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def migrations_exist():
     """
     Check if there exists database migrations to run

--- a/fab/operations/release.py
+++ b/fab/operations/release.py
@@ -7,6 +7,7 @@ from fabric.colors import red
 from fabric.context_managers import cd, settings
 from fabric.contrib import files
 from fabric import utils
+from fabric.decorators import runs_once
 
 from ..const import (
     ROLES_ALL_SRC,
@@ -103,6 +104,7 @@ def create_code_dir():
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def kill_stale_celery_workers(delay=0):
     with cd(env.code_current):
         sudo(
@@ -113,6 +115,7 @@ def kill_stale_celery_workers(delay=0):
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def record_successful_deploy():
     start_time = datetime.strptime(env.deploy_metadata.timestamp, DATE_FMT)
     delta = datetime.utcnow() - start_time

--- a/fab/operations/staticfiles.py
+++ b/fab/operations/staticfiles.py
@@ -1,5 +1,7 @@
 from fabric.api import roles, parallel, sudo, env
 from fabric.context_managers import cd
+from fabric.decorators import runs_once
+
 from fab.utils import bower_command
 
 from ..const import ROLES_STATIC, ROLES_DJANGO, ROLES_ALL_SRC, ROLES_DB_ONLY
@@ -18,6 +20,7 @@ def version_static():
 
 
 @roles(ROLES_DB_ONLY)
+@runs_once
 def prime_version_static():
     """
     Run version static on the DB machine to prime the version_static cache so


### PR DESCRIPTION
With multiple DB machines e.g. NIC these tasks all get run once per host which isn't required.

Not yet tested hence the label.

@benrudolph 
buddy @biyeun 

ref: http://docs.fabfile.org/en/latest/api/core/decorators.html#fabric.decorators.runs_once