### PR TITLE
Do not do a double restart for monoliths

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -68,6 +68,7 @@ from utils import (
     retrieve_cached_deploy_env,
     retrieve_cached_deploy_checkpoint,
     traceback_string,
+    is_monolith,
 )
 
 
@@ -683,7 +684,8 @@ def silent_services_restart(use_current_release=False):
     Restarts services and sets the in progress flag so that pingdom doesn't yell falsely
     """
     execute(db.set_in_progress_flag, use_current_release)
-    execute(supervisor.restart_all_except_webworkers)
+    if not is_monolith():
+        execute(supervisor.restart_all_except_webworkers)
     execute(supervisor.restart_webworkers)
 
 

--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -24,7 +24,7 @@ from ..const import (
     ROLES_ALL_SERVICES,
 )
 from fabric import utils
-from ..utils import execute_with_timing, get_pillow_env_config
+from ..utils import execute_with_timing, get_pillow_env_config, is_monolith
 
 
 def set_supervisor_config():
@@ -313,7 +313,7 @@ def _check_and_reload_nginx():
 
 @contextmanager
 def decommissioned_host(host):
-    not_monolith = len(env.roledefs['django_app']) > 1
+    not_monolith = not is_monolith()
     if not_monolith:
         execute(_decommission_host, host)
 
@@ -328,7 +328,6 @@ def decommissioned_host(host):
 def restart_webworkers():
     with decommissioned_host(env.host):
         _services_restart()
-
 
 
 @roles(ROLES_FORMPLAYER)

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -182,6 +182,10 @@ def traceback_string():
     )
 
 
+def is_monolith():
+    return len(env.roledefs['django_app']) == 1
+
+
 def pip_install(cmd_prefix, requirements, timeout=None, quiet=False, proxy=None):
     parts = [cmd_prefix, 'pip install']
     if timeout is not None:


### PR DESCRIPTION
@mkangia / anyone.  realized we were restarting services twice on monoliths since we don't actually group our supervisor tasks. we just restart by machine. this should also fix the celery stale worker issue on swiss