### PR TITLE
Run create_kafka_topics on deploy

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -476,6 +476,7 @@ def _deploy_without_asking():
         supervisor.set_supervisor_config,
         formplayer.build_formplayer,
         conditionally_stop_pillows_and_celery_during_migrate,
+        db.create_kafka_topics,
         db.flip_es_aliases,
         staticfiles.update_manifest,
         release.clean_releases,

--- a/fab/operations/db.py
+++ b/fab/operations/db.py
@@ -114,3 +114,11 @@ def migrations_exist():
             # failed to return a value python could parse into an int
             return True
         return n_migrations > 0
+
+
+@roles(ROLES_DB_ONLY)
+def create_kafka_topics():
+    """Create kafka topics if needed.  This is pretty fast."""
+    with cd(env.code_root):
+        sudo('%(virtualenv_root)s/bin/python manage.py create_kafka_topics' % env)
+


### PR DESCRIPTION
This is pretty quick when it's a noop, so I don't think it's a big deal to add.  I just tested `$ time fab staging manage:create_kafka_topics` and it took 7 seconds.

I'm not sure exactly when is the most appropriate place to add this, and would be willing to hear second opinions.