### PR TITLE
Fix mail admins

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -29,6 +29,7 @@ import datetime
 import os
 import posixpath
 import yaml
+import pipes
 from distutils.util import strtobool
 
 from fabric import utils
@@ -323,9 +324,9 @@ def mail_admins(subject, message):
             'mail_admins --subject "%(subject)s" "%(message)s" --slack --environment %(environment)s'
         ) % {
             'virtualenv_root': env.virtualenv_root,
-            'subject': subject,
-            'message': message,
-            'environment': env.environment,
+            'subject': pipes.quote(subject),
+            'message': pipes.quote(message),
+            'environment': pipes.quote(env.environment),
         })
 
 
@@ -514,7 +515,8 @@ def _deploy_without_asking():
     except Exception:
         execute_with_timing(
             mail_admins,
-            "Deploy to {environment} failed. Try resuming with 'fab {environment} deploy:resume=yes'.".format(environment=env.environment),
+            "Deploy to {environment} failed. Try resuming with "
+            "fab {environment} deploy:resume=yes.".format(environment=env.environment),
             traceback_string()
         )
         # hopefully bring the server back to life

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -179,7 +179,7 @@ def traceback_string():
         trace=trace,
         type=exc_type.__name__,
         exc=exc,
-    ).replace('"', '\\"')
+    )
 
 
 def pip_install(cmd_prefix, requirements, timeout=None, quiet=False, proxy=None):

--- a/fab/utils.py
+++ b/fab/utils.py
@@ -179,7 +179,7 @@ def traceback_string():
         trace=trace,
         type=exc_type.__name__,
         exc=exc,
-    )
+    ).replace('"', '\\"')
 
 
 def pip_install(cmd_prefix, requirements, timeout=None, quiet=False, proxy=None):


### PR DESCRIPTION
@millerdev I believe the quotes were not properly escaped when sending the traceback to `mail_admins` and actually caused the failed command to be run again. this was based off looking at the traceback you sent me:

```
[hqdb1-staging.internal-va.commcarehq.org] out: usage: manage.py migrate_multi [-h] [--version] [-v {0,1,2,3}]
[hqdb1-staging.internal-va.commcarehq.org] out:                                [--settings SETTINGS] [--pythonpath PYTHONPATH]
[hqdb1-staging.internal-va.commcarehq.org] out:                                [--traceback] [--no-color] [--noinput] [--fake]
[hqdb1-staging.internal-va.commcarehq.org] out:                                [--list]
[hqdb1-staging.internal-va.commcarehq.org] out:                                [app_label] [migration_name]
[hqdb1-staging.internal-va.commcarehq.org] out: manage.py migrate_multi: error: unrecognized arguments: --slack --environment`
```
that should definitely never be run with those arguments