### PR TITLE
Increase max perm gen size

### DIFF
--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
-command=java -javaagent:/home/cchq/www/{{ environment }}/newrelic/newrelic.jar -jar -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9999 -Xmx{{ formplayer_memory }} -Xss1024k {{ code_current}}/formplayer_build/formplayer.jar
+command=java -javaagent:/home/cchq/www/{{ environment }}/newrelic/newrelic.jar -jar -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9999 -Xmx{{ formplayer_memory }} -XX:MaxPermSize=128m -Xss1024k {{ code_current}}/formplayer_build/formplayer.jar
 user={{ sudo_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
@wpride @snopoke this increases the max perm gen size on formplayer. i inspected the jmx memoryusage bean and found that we were are near the max on that:

```
Usage = {
  committed = 85983232;
  init = 22020096;
  max = 85983232;
  used = 85706448;
 };
```
this memory is used for storing permanent objects like class meta data. trying to get this info into datadog. there are some good posts about all the different memory types in java, here's one that's a quick read: http://www.freshblurbs.com/blog/2005/05/19/explaining-java-lang-outofmemoryerror-permgen-space.html
cc: @emord 