### PR TITLE
Remove formplayer machine

### DIFF
--- a/fab/inventory/softlayer
+++ b/fab/inventory/softlayer
@@ -85,7 +85,6 @@ touch0
 
 [formplayer:children]
 formplayer0
-formplayer1
 
 [redis:children]
 db0


### PR DESCRIPTION
@czue Despite the commit name, this is actually removing a formplayer machine. I'm taking one out of commission for load testing. Load on formplayer with one machine should be totally fine

cc: @kaapstorm