### PR TITLE
Revert "add proxy vars to supervisor config"

### DIFF
--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -244,18 +244,15 @@ def _format_env(current_env, extra=None):
     newrelic_machines = [machine.name
                          for group in inventory_groups for machine in group.hosts
                          if 'newrelic_app_name' in group.vars]
-
-    ret['new_relic_command'] = ''
-    ret['supervisor_env_vars'] = {}
-
     if host in newrelic_machines:
         ret['new_relic_command'] = '%(virtualenv_root)s/bin/newrelic-admin run-program ' % env
-        ret['supervisor_env_vars']['NEW_RELIC_CONFIG_FILE'] = '%(root)s/newrelic.ini' % env
-        ret['supervisor_env_vars']['NEW_RELIC_ENVIRONMENT'] = '%(environment)s' % env
-
-    if env.http_proxy:
-        ret['supervisor_env_vars']['http_proxy'] = 'http://{}'.format(env.http_proxy)
-        ret['supervisor_env_vars']['https_proxy'] = 'https://{}'.format(env.http_proxy)
+        ret['supervisor_env_vars'] = {
+            'NEW_RELIC_CONFIG_FILE': '%(root)s/newrelic.ini' % env,
+            'NEW_RELIC_ENVIRONMENT': '%(environment)s' % env
+        }
+    else:
+        ret['new_relic_command'] = ''
+        ret['supervisor_env_vars'] = []
 
     for prop in important_props:
         ret[prop] = current_env.get(prop, '')


### PR DESCRIPTION
Reverts dimagi/commcare-hq-deploy#224
@emord cc: @snopoke @benrudolph @javierwilson 
the proxy variable was causing the webworker requests to riak (and i think formplayer) to be routed through the squid proxy and then fail. we fixed this manually on NIC but this will help future deploys until we figure out the proper way to do add in the proxy.