### PR TITLE
Reduce max tasks per child

### DIFF
--- a/fab/services/templates/supervisor_celery_background_queue.conf
+++ b/fab/services/templates/supervisor_celery_background_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_background_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=background_queue --events --loglevel=INFO --hostname={{ host_string }}_background_queue --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=background_queue --events --loglevel=INFO --hostname={{ host_string }}_background_queue --maxtasksperchild=1 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_saved_exports_queue.conf
+++ b/fab/services/templates/supervisor_celery_saved_exports_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_saved_exports_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command=/bin/bash {{ code_current }}/services/supervisor/{{ environment }}_celery_bash_runner.sh --queues=saved_exports_queue --events --loglevel=INFO --hostname={{ host_string }}_saved_exports_queue --maxtasksperchild=5 --autoscale={{ celery_params.concurrency }},0 -Ofair
+command=/bin/bash {{ code_current }}/services/supervisor/{{ environment }}_celery_bash_runner.sh --queues=saved_exports_queue --events --loglevel=INFO --hostname={{ host_string }}_saved_exports_queue --maxtasksperchild=1 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1


### PR DESCRIPTION
@calellowitz @benrudolph 

In the short term this might help a little bit with the out of memory errors (I think the longer term solution is to do some profiling on the tasks running on the machine. There seemed to be a lot of `corehq.apps.export.tasks.rebuild_export_task` tasks running when it happens which might be related.)

Essentially with this we'll replace a worker child process after every task instead of every 5 tasks, so for example in the background worker since it has concurrency 4, instead of keeping in memory the effects of up to 20 tasks, it will only keep around the effects of up to 4 tasks.