### PR TITLE
async indicator no gevent

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -46,7 +46,7 @@ softlayer:
       ucr_queue:
         concurrency: 4
       ucr_indicator_queue:
-        concurrency: 10
+        concurrency: 1
       email_queue:
         concurrency: 2
       repeat_record_queue:
@@ -87,7 +87,7 @@ icds:
       ucr_queue:
         concurrency: 4
       ucr_indicator_queue:
-        concurrency: 10
+        concurrency: 4
       email_queue:
         concurrency: 2
       repeat_record_queue:
@@ -115,7 +115,7 @@ production:
       ucr_queue:
         concurrency: 4
       ucr_indicator_queue:
-        concurrency: 10
+        concurrency: 1
     hqcelery1:
       reminder_case_update_queue:
         concurrency: 4

--- a/fab/services/templates/supervisor_celery_ucr_indicator_queue.conf
+++ b/fab/services/templates/supervisor_celery_ucr_indicator_queue.conf
@@ -1,13 +1,13 @@
 [program:{{ project }}-{{ environment }}-celery_ucr_indicator_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=ucr_indicator_queue --events --loglevel=INFO --hostname={{ host_string }}_ucr_indicator_queue -P gevent --concurrency={{ celery_params.concurrency }}
+command=/bin/bash {{ code_current }}/services/supervisor/{{ environment }}_celery_bash_runner.sh --queues=ucr_indicator_queue --events --loglevel=INFO --hostname={{ host_string }}_ucr_indicator_queue --maxtasksperchild=50 --autoscale={{ celery_params.concurrency }},0 -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1
 autostart=true
 autorestart=true
-stopasgroup=true
-killasgroup=true
+stopasgroup=false
+killasgroup=false
 stdout_logfile={{ log_dir }}/celery_ucr_indicator_queue.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/celery_ucr_indicator_queue.error.log


### PR DESCRIPTION
This stops using gevent for this queue. It turned out that this is more cpu bound than network bound.

when running one task it took about ~90s, with two tasks running it was around ~200s each, so there was nothing to be gained from gevent. using 1 queue for prod/softlayer, 4 for icds

@gcapalbo @kaapstorm 