### PR TITLE
Only deploy tasks to celery0

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -78,7 +78,6 @@ icds:
         concurrency: 4
       ucr_indicator_queue:
         concurrency: 4
-    'celery1':
       background_queue:
         concurrency: 4
       reminder_case_update_queue:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -64,16 +64,23 @@ icds:
   formplayer_memory: "16000m"
   gunicorn_workers_static_factor: 1
   celery_processes:
-    '*':
+    'celery0':
       main:
         concurrency: 8
-      background_queue:
-        concurrency: 4
       periodic:
         concurrency: 4
         server_whitelist: 10.247.24.19
       pillow_retry_queue:
         concurrency: 1
+      repeat_record_queue:
+        concurrency: 3
+      ucr_queue:
+        concurrency: 4
+      ucr_indicator_queue:
+        concurrency: 4
+    'celery1':
+      background_queue:
+        concurrency: 4
       reminder_case_update_queue:
         concurrency: 4
       reminder_queue:
@@ -84,14 +91,8 @@ icds:
         concurrency: 3
       sms_queue:
         concurrency: 8
-      ucr_queue:
-        concurrency: 4
-      ucr_indicator_queue:
-        concurrency: 4
       email_queue:
         concurrency: 2
-      repeat_record_queue:
-        concurrency: 3
       async_restore_queue:
         concurrency: 4
       flower: {}


### PR DESCRIPTION
Don't really need to split these up right now, but realized this is necessary when https://github.com/dimagi/commcare-hq-deploy/pull/237 is deployed. otherwise it would have run two instances of the queues, one on each machine. I wasn't sure if that was a safe operation or not.

@gcapalbo @snopoke @calellowitz 