### PR TITLE
don't use quotes

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -64,7 +64,7 @@ icds:
   formplayer_memory: "16000m"
   gunicorn_workers_static_factor: 1
   celery_processes:
-    'celery0':
+    celery0:
       main:
         concurrency: 8
       periodic:


### PR DESCRIPTION
@sravfeyn @calellowitz I think this is why there weren't supervisor configs in the new directory