### PR TITLE
fix icds celery deploy

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -64,7 +64,7 @@ icds:
   formplayer_memory: "16000m"
   gunicorn_workers_static_factor: 1
   celery_processes:
-    celery0:
+    '10.247.24.19': # celery0
       main:
         concurrency: 8
       periodic:

--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -50,9 +50,8 @@ def _get_celery_queues():
         host = full_host.split('.')[0]
 
     queues = env.celery_processes.get('*', {})
-    host_queues = env.celery_processes.get(host, {})
-    host_queues = env.celery_processes.get(full_host, {})
-    queues.update(host_queues)
+    queues.update(env.celery_processes.get(host, {}))
+    queues.update(env.celery_processes.get(full_host, {}))
 
     return queues
 

--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -45,12 +45,13 @@ def set_supervisor_config():
 
 
 def _get_celery_queues():
-    host = env.get('host_string')
-    if host and '.' in host:
-        host = host.split('.')[0]
+    full_host = env.get('host_string')
+    if full_host and '.' in full_host:
+        host = full_host.split('.')[0]
 
     queues = env.celery_processes.get('*', {})
     host_queues = env.celery_processes.get(host, {})
+    host_queues = env.celery_processes.get(full_host, {})
     queues.update(host_queues)
 
     return queues


### PR DESCRIPTION
@dimagi/scale-team this should fix the issues i was seeing where celery queue's supervisor ocnfigs weren't being set

On prod (only place where this was being hit) we have DNS set up so host strings of celery0.internal-va.commcarehq.org so host_string split by '.' would have been 'celery0'

On icds the host strings are '10.247.24.x' so splitting by '.' would be 10 which is why celery0 wasn't matching.

This change will support both of those for now. I'm not sure how feasible it is to get private DNS set up for icds

@millerdev 