### PR TITLE
combine icds pillows

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -177,6 +177,8 @@ icds:
         num_processes: 1
       kafka-ucr-static-awc-location:
         num_processes: 1
+      kafka-ucr-static-cases:
+        num_processes: 4
       kafka-ucr-static-ccs_record_cases:
         num_processes: 1
       kafka-ucr-static-ccs_record_cases_monthly:
@@ -191,11 +193,7 @@ icds:
         num_processes: 1
       kafka-ucr-static-gm_forms:
         num_processes: 1
-      kafka-ucr-static-hardware_cases:
-        num_processes: 1
       kafka-ucr-static-home_visit_forms:
-        num_processes: 1
-      kafka-ucr-static-household_cases:
         num_processes: 1
       kafka-ucr-static-infrastructure_form:
         num_processes: 1
@@ -205,10 +203,6 @@ icds:
         num_processes: 1
       kafka-ucr-static-person_cases:
         num_processes: 2
-      kafka-ucr-static-tasks_cases:
-        num_processes: 1
-      kafka-ucr-static-tech_issue_cases:
-        num_processes: 1
       kafka-ucr-static-thr_forms:
         num_processes: 1
       kafka-ucr-static-usage_forms:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -179,36 +179,20 @@ icds:
         num_processes: 1
       kafka-ucr-static-cases:
         num_processes: 4
+      kafka-ucr-static-forms-A:
+        num_processes: 4
+      kafka-ucr-static-forms-B:
+        num_processes: 4
       kafka-ucr-static-ccs_record_cases:
         num_processes: 1
       kafka-ucr-static-ccs_record_cases_monthly:
         num_processes: 2
       kafka-ucr-static-child_cases_monthly:
         num_processes: 1
-      kafka-ucr-static-child_delivery_forms:
-        num_processes: 1
       kafka-ucr-static-child_health_cases:
         num_processes: 2
-      kafka-ucr-static-daily_feeding_forms:
-        num_processes: 1
-      kafka-ucr-static-gm_forms:
-        num_processes: 1
-      kafka-ucr-static-home_visit_forms:
-        num_processes: 1
-      kafka-ucr-static-infrastructure_form:
-        num_processes: 1
-      kafka-ucr-static-ls_home_visit_forms_filled:
-        num_processes: 1
-      kafka-ucr-static-other-forms:
-        num_processes: 1
       kafka-ucr-static-person_cases:
         num_processes: 2
-      kafka-ucr-static-thr_forms:
-        num_processes: 1
-      kafka-ucr-static-usage_forms:
-        num_processes: 1
-      kafka-ucr-static-vhnd_form:
-        num_processes: 1
       KafkaDomainPillow:
         num_processes: 1
       LedgerToElasticsearchPillow:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -128,8 +128,6 @@ icds:
         concurrency: 3
       ucr_queue:
         concurrency: 4
-      ucr_indicator_queue:
-        concurrency: 4
       background_queue:
         concurrency: 4
       reminder_case_update_queue:
@@ -147,6 +145,9 @@ icds:
       async_restore_queue:
         concurrency: 4
       flower: {}
+    '10.247.24.31': # celery1
+      ucr_indicator_queue:
+        concurrency: 8
   pillows:
     '10.247.24.20': # pillow0
       AppDbChangeFeedPillow:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -148,7 +148,7 @@ icds:
         concurrency: 4
       flower: {}
   pillows:
-    '*':
+    '10.247.24.20': # pillow0
       AppDbChangeFeedPillow:
         num_processes: 1
       ApplicationBlobDeletionPillow:
@@ -179,10 +179,6 @@ icds:
         num_processes: 1
       kafka-ucr-static-cases:
         num_processes: 4
-      kafka-ucr-static-forms-A:
-        num_processes: 4
-      kafka-ucr-static-forms-B:
-        num_processes: 4
       kafka-ucr-static-ccs_record_cases:
         num_processes: 4
       kafka-ucr-static-ccs_record_cases_monthly:
@@ -209,6 +205,11 @@ icds:
         num_processes: 1
       XFormToElasticsearchPillow:
         num_processes: 1
+    '10.247.24.30': # pillow1
+      kafka-ucr-static-forms-A:
+        num_processes: 4
+      kafka-ucr-static-forms-B:
+        num_processes: 4
 
 
 production:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -184,9 +184,9 @@ icds:
       kafka-ucr-static-forms-B:
         num_processes: 4
       kafka-ucr-static-ccs_record_cases:
-        num_processes: 1
+        num_processes: 4
       kafka-ucr-static-ccs_record_cases_monthly:
-        num_processes: 2
+        num_processes: 4
       kafka-ucr-static-child_cases_monthly:
         num_processes: 1
       kafka-ucr-static-child_health_cases:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -190,7 +190,7 @@ icds:
       kafka-ucr-static-child_cases_monthly:
         num_processes: 1
       kafka-ucr-static-child_health_cases:
-        num_processes: 2
+        num_processes: 4
       kafka-ucr-static-person_cases:
         num_processes: 2
       KafkaDomainPillow:

--- a/fab/inventory/icds
+++ b/fab/inventory/icds
@@ -215,6 +215,7 @@ celery1
 
 [pillowtop:children]
 pil0
+pil1
 
 [touchforms:children]
 pil1


### PR DESCRIPTION
This will combine some form and case pillows on icds. 

It also decreases # of processes by 8 on pillow0 and adds 8 to pillow1 (currently has users couch db on it).

 I also added four workers to the ucr indicator queue and moved it to celery1 (which is currently unused). It'll mean that we update the child health monthly ucrs more quickly and better utilize celery1.

@dimagi/scale-team @dannyroberts 

I'll coordinate this deploy with https://github.com/dimagi/commcarehq-ansible/pull/740 and creating kafka partitions for form-sql