### PR TITLE
bump up ucr workers

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -144,10 +144,12 @@ icds:
         concurrency: 2
       async_restore_queue:
         concurrency: 4
+      ucr_indicator_queue:
+        concurrency: 8
       flower: {}
     '10.247.24.31': # celery1
       ucr_indicator_queue:
-        concurrency: 8
+        concurrency: 12
   pillows:
     '10.247.24.20': # pillow0
       AppDbChangeFeedPillow:


### PR DESCRIPTION
@dannyroberts as mentioned https://github.com/dimagi/commcare-hq/pull/16122

celery1 is at about 50% cpu. celery0 is < 10% so this shouldn't cause any resource issues

@gcapalbo you said that it's acceptable to have the same worker on two different machines because they have different hostnames right?