### PR TITLE
Revert "Temporarily shift celery workers to celery0"

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -41,7 +41,7 @@ softlayer:
         concurrency: 8
       saved_exports_queue:
         concurrency: 3
-    #'10.162.36.194':  # celery1
+    '10.162.36.194':  # celery1
       reminder_case_update_queue:
         concurrency: 4
       reminder_queue:


### PR DESCRIPTION
Reverts dimagi/commcare-hq-deploy#272

whitelisting issue is resolved, going to put the workers back on celery1