### PR TITLE
utilize turned off web workers

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -150,6 +150,12 @@ icds:
       flower: {}
     '10.247.24.31': # celery1
       ucr_indicator_queue:
+        concurrency: 16
+    '10.247.24.15': # web1
+      ucr_indicator_queue:
+        concurrency: 12
+    '10.247.24.24': # web2
+      ucr_indicator_queue:
         concurrency: 12
   pillows:
     '10.247.24.20': # pillow0

--- a/fab/inventory/icds
+++ b/fab/inventory/icds
@@ -244,6 +244,8 @@ kafka0
 kafka0
 
 [celery:children]
+web1
+web2
 celery0
 celery1
 


### PR DESCRIPTION
Talked about this with @calellowitz 

We're going to need to build the tables for the new v2 UCRs for icds-cas soon, and these webworkers currently aren't doing anything. Makes sense to turn them into celery workers (at least temporarily) so that they can go through the queue much faster.

@snopoke buddy @orangejenny 