### PR TITLE
remove couchdb from inventory on icds

### DIFF
--- a/fab/inventory/icds
+++ b/fab/inventory/icds
@@ -220,10 +220,6 @@ pg1
 pg2
 pg3
 
-[couchdb:children]
-couch0
-pil1
-
 [couchdb2:children]
 couch0
 pil1


### PR DESCRIPTION
@orangejenny no more couch 1. will need to migrate swiss before removing the role though