### PR TITLE
icds updates

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -230,9 +230,9 @@ icds:
       kafka-ucr-static-forms:
         num_processes: 8
       kafka-ucr-main:
-        num_processes: 4
+        num_processes: 2
       kafka-ucr-static-test:
-        num_processes: 8
+        num_processes: 2
       KafkaDomainPillow:
         num_processes: 1
       LedgerToElasticsearchPillow:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -184,10 +184,10 @@ icds:
         concurrency: 16
     '10.247.24.15': # web1
       ucr_indicator_queue:
-        concurrency: 12
+        concurrency: 16
     '10.247.24.24': # web2
       ucr_indicator_queue:
-        concurrency: 12
+        concurrency: 16
   pillows:
     '10.247.24.20': # pillow0
       AppDbChangeFeedPillow:

--- a/fab/inventory/icds
+++ b/fab/inventory/icds
@@ -208,8 +208,6 @@ web0
 
 [webworkers:children]
 web0
-web1
-web2
 web3
 web4
 web5


### PR DESCRIPTION
- reduces pillows that icds-cas isn't using.
- removes web1 and web2 from webworkers so that an ansible deploy doesn't add those back
- Bumps up the async indicator concurrency on web1/web2

@snopoke @calellowitz @orangejenny 