### PR TITLE
Removed old pillows

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -224,8 +224,6 @@ icds:
         num_processes: 1
       kafka-ucr-static-cases:
         num_processes: 16
-      kafka-ucr-static-ccs_record_cases_monthly:
-        num_processes: 8
       kafka-ucr-static-person_cases:
         num_processes: 8
     '10.247.24.30': # pillow1
@@ -236,9 +234,7 @@ icds:
       kafka-ucr-static-forms:
         num_processes: 8
       kafka-ucr-main:
-        num_processes: 2
-      kafka-ucr-static-test:
-        num_processes: 4
+        num_processes: 1
       KafkaDomainPillow:
         num_processes: 1
       LedgerToElasticsearchPillow:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -223,7 +223,7 @@ icds:
       kafka-ucr-static-awc-location:
         num_processes: 1
       kafka-ucr-static-cases:
-        num_processes: 16
+        num_processes: 24
       kafka-ucr-static-person_cases:
         num_processes: 8
     '10.247.24.30': # pillow1


### PR DESCRIPTION
will likely want to bump case-sql to 24 partitions this week-ish and add 8 process to kafka-ucr-static-cases. but as of now it catches up quickly

https://github.com/dimagi/commcarehq-ansible/pull/819

@calellowitz 