### PR TITLE
Add celery workers to web workers for icds

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -197,9 +197,21 @@ icds:
     '10.247.24.31': # celery1
       ucr_indicator_queue:
         concurrency: 16
+    '10.247.24.15': # web1
+      ucr_indicator_queue:
+        concurrency: 8
     '10.247.24.24': # web2
       ucr_indicator_queue:
         concurrency: 16
+    '10.247.24.25': # web3
+      ucr_indicator_queue:
+        concurrency: 8
+    '10.247.24.26': # web4
+      ucr_indicator_queue:
+        concurrency: 8
+    '10.247.24.27': # web5
+      ucr_indicator_queue:
+        concurrency: 8
   pillows:
     '10.247.24.20': # pillow0
       AppDbChangeFeedPillow:


### PR DESCRIPTION
@dimagi/scale-team combined with https://github.com/dimagi/commcare-hq/pull/16868 these will only run in the night. keeping them at 8 instead of 16 for at least today so we can make srue there's not degraded performance overnight