### PR TITLE
use hostname instead of ip address

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -323,14 +323,14 @@ production:
         concurrency: 4
         max_tasks_per_child: 1
   pillows:
-    '172.24.32.50':
+    hqpillowtop1:
       kafka-ucr-main-08:
         num_processes: 1
       kafka-ucr-main-9f:
         num_processes: 1
       kafka-ucr-static:
         num_processes: 1
-    '172.24.32.27':
+    hqpillowtop0:
       AppDbChangeFeedPillow:
         num_processes: 1
       ApplicationBlobDeletionPillow:


### PR DESCRIPTION
@javierwilson @mkangia @dannyroberts 

Just hotfixed this on prod. Not sure why this didn't work, but pillows weren't running for the past 4.5 hours. I think IP addresses should always work, but it looks like they don't on prod, and hostnames don't work on softlyaer/icds, so it's pretty confusing.