### PR TITLE
Split async restore worker to two workers on prod

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -303,6 +303,9 @@ production:
         max_tasks_per_child: 5
       ucr_indicator_queue:
         concurrency: 1
+      async_restore_queue:
+        concurrency: 2
+        max_tasks_per_child: 5
     hqcelery1:
       reminder_case_update_queue:
         pooling: gevent
@@ -325,7 +328,8 @@ production:
         concurrency: 2
         max_tasks_per_child: 5
       async_restore_queue:
-        concurrency: 4
+        concurrency: 2
+        max_tasks_per_child: 5
       flower: {}
     hqcelery2:
       celery:


### PR DESCRIPTION
https://app.datadoghq.com/notebook/9666/Prod-Celery-memory-usage

Looks like we have some capacity on hqcelery0 but hqcelery1 is continuously running out of memory. The async restore child worker processes each take up about 10% memory usage of the machine so this splits it into two workers on two different machines. Also reduced the max tasks per child setting to help reduce effects of memory leaking.

@dannyroberts 