### PR TITLE
add 8G swap to all production celery machines

### DIFF
--- a/fab/inventory/production
+++ b/fab/inventory/production
@@ -31,6 +31,7 @@ hqcelery2.internal-va.commcarehq.org
 
 [celery:vars]
 newrelic_app_name=celery
+swap_size=8G
 
 [pillowtop]
 hqpillowtop0.internal-va.commcarehq.org


### PR DESCRIPTION
I chose 8G because it's equal to the total amount of RAM. Assuming we'll continue our tendency of using all machines to the max, this means that when we restart celery processes and the number of processes temporarily doubles, we'll still be well within the limits of RAM + swap so the OS won't be forced to use its oom killer. In addition, all three VMs have large drives of which they're currently using < 30%, so reserving 8G of disk for swap shouldn't be an issue.