### PR TITLE
Added more celery processes for ucr indicators.

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -192,7 +192,7 @@ icds:
       async_restore_queue:
         concurrency: 4
       ucr_indicator_queue:
-        concurrency: 8
+        concurrency: 16
         celery_loader: 'corehq.util.celery_utils.LoadBasedLoader'
       flower: {}
     '10.247.24.31': # celery1
@@ -201,7 +201,7 @@ icds:
         celery_loader: 'corehq.util.celery_utils.LoadBasedLoader'
     '10.247.24.15': # web1
       ucr_indicator_queue:
-        concurrency: 12
+        concurrency: 16
         celery_loader: 'corehq.util.celery_utils.OffPeakLoadBasedLoader'
     '10.247.24.24': # web2
       ucr_indicator_queue:
@@ -209,19 +209,19 @@ icds:
         celery_loader: 'corehq.util.celery_utils.OffPeakLoadBasedLoader'
     '10.247.24.25': # web3
       ucr_indicator_queue:
-        concurrency: 12
+        concurrency: 16
         celery_loader: 'corehq.util.celery_utils.OffPeakLoadBasedLoader'
     '10.247.24.26': # web4
       ucr_indicator_queue:
-        concurrency: 12
+        concurrency: 16
         celery_loader: 'corehq.util.celery_utils.OffPeakLoadBasedLoader'
     '10.247.24.27': # web5
       ucr_indicator_queue:
-        concurrency: 12
+        concurrency: 16
         celery_loader: 'corehq.util.celery_utils.OffPeakLoadBasedLoader'
     '10.247.24.13': # web0
       ucr_indicator_queue:
-        concurrency: 8
+        concurrency: 12
         celery_loader: 'corehq.util.celery_utils.OffPeakLoadBasedLoader'
     '10.247.24.21': # kafka0
       ucr_indicator_queue:


### PR DESCRIPTION
I'm more confident with this now that we have a load based scheduler so it shouldn't totally take over machine cpu. still being cautious with nginx and kafka though

@esoergel 