### PR TITLE
Reduce number of case update queue workers

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -172,7 +172,7 @@ icds:
       reminder_case_update_queue:
         pooling: gevent
         concurrency: 5
-        num_workers: 8
+        num_workers: 4
       reminder_queue:
         pooling: gevent
         concurrency: 5


### PR DESCRIPTION
We were able to keep up with the load earlier today with just 2, so reducing this a bit.
@emord 