### PR TITLE
Better supervisor usage on restart.

### DIFF
--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -380,8 +380,8 @@ def _services_restart():
     """Stop and restart all supervisord services"""
     supervisor_command('stop all')
 
+    supervisor_command('reread')
     supervisor_command('update')
-    supervisor_command('reload')
     time.sleep(5)
     supervisor_command('start all')
 


### PR DESCRIPTION
supervisor has pretty crappy docs, but I believe that this is the behavior we want.

`reread` will update configurations but will not restart applications
`update` will update configurations and restart them. It also allows new configurations to start (but doesn't start them automatically).
`reload` is not documented

Whenver we make a change to celery configurations we get a lot of errors around this code. I think that's because we run update first which reads the new configuration and then starts the process.

This change will reload all configurations, update will enable any new processes to start, and then start all will actually start the configurations. 

I'm hoping this solves the issues we've seen when changing celery worker configurations.

@gcapalbo buddy @nickpell 