### PR TITLE
More background queue processes

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -199,6 +199,9 @@ icds:
     '10.247.24.31': # celery1
       ucr_indicator_queue:
         concurrency: 16
+      background_queue:
+        concurrency: 4
+        max_tasks_per_child: 1
     '10.247.24.15': # web1
       ucr_indicator_queue:
         concurrency: 12


### PR DESCRIPTION
The background queue is pretty backed up on icds. Ideally we should probably re-evaluate what gets sent there, but adding this to celery1 seems fine

@gcapalbo @dimagi/scale-team @nickpell 