### PR TITLE
parallel supervisor

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -802,7 +802,7 @@ def silent_services_restart(use_current_release=False):
 @task
 def set_supervisor_config():
     setup_release()
-    supervisor.set_supervisor_config()
+    execute_with_timing(supervisor.set_supervisor_config)
 
 
 @task

--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -292,6 +292,7 @@ def _format_env(current_env, extra=None):
 
 
 @roles(ROLES_PILLOWTOP)
+@parallel
 def stop_pillows(current=False):
     code_root = env.code_current if current else env.code_root
     with cd(code_root):
@@ -299,6 +300,7 @@ def stop_pillows(current=False):
 
 
 @roles(ROLES_PILLOWTOP)
+@parallel
 def start_pillows(current=False):
     code_root = env.code_current if current else env.code_root
     with cd(code_root):


### PR DESCRIPTION
This will allow parallel supervisor services config generation. Before the workflow was generate all celery configs, generate all django configs,  ... This changes it to one step of generating all configs on every server at one time.

I think this would be a lot of faster if we moved it away from a manage.py command. Those commands are so slow to startup

@benrudolph @biyeun 