### PR TITLE
Use number of webworkers instead of is_monolith flag to determine decommissioning

### DIFF
--- a/fab/operations/supervisor.py
+++ b/fab/operations/supervisor.py
@@ -357,13 +357,14 @@ def _check_and_reload_nginx():
 
 @contextmanager
 def decommissioned_host(host):
-    not_monolith = not env.is_monolith
-    if not_monolith:
+    more_than_one_webworker = len(env.roledefs['django_app']) > 1
+
+    if more_than_one_webworker:
         execute(_decommission_host, host)
 
     yield
 
-    if not_monolith:
+    if more_than_one_webworker:
         execute(_recommission_host, host)
 
 


### PR DESCRIPTION
Since enikshay has is_monolith = False but also only has one webworker, the deploy is trying to comment the webworker out of nginx config during deploy when restarting it, but that leaves no webworkers left.

@javierwilson @snopoke @mkangia 