### PR TITLE
Remove the partitioned ucr pillow from prod

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -446,9 +446,7 @@ production:
         max_tasks_per_child: 1
   pillows:
     hqpillowtop1:
-      kafka-ucr-main-08:
-        num_processes: 4
-      kafka-ucr-main-9f:
+      kafka-ucr-main:
         num_processes: 4
       kafka-ucr-static:
         num_processes: 1


### PR DESCRIPTION
This removes a workaround to get multiple pillows to process ucr changes. going to remove this now that we have proper partitioning. will need a bit of coordination when it gets deployed  on monday so putting hte don't merge label on there for now

@nickpell 