### PR TITLE
Run supervisor commands in parallel.

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -771,6 +771,7 @@ def awesome_deploy(confirm="yes", resume='no', offline='no'):
 
 
 @task
+@parallel
 def supervisorctl(command):
     require('supervisor_roles',
             provided_by=('staging', 'production', 'softlayer'))


### PR DESCRIPTION
@biyeun @proteusvacuum 

This will run commands in parallel so that commands like `fab icds supervisorctl:"stop commcare-hq-icds-celery_ucr_indicator_queue_0"` will finish more quickly