### PR TITLE
rework formplayer directory structure

### DIFF
--- a/fab/operations/formplayer.py
+++ b/fab/operations/formplayer.py
@@ -44,8 +44,9 @@ def build_formplayer(use_current_release=False):
         # (not because it's the name we chose for the zip file)
         sudo("unzip archive.zip".format(build_dir, release_name))
         sudo("mv archive/build {}".format(release_name))
-        sudo('ln -sf {} current'.format(release_name))
+        sudo('ln -sfn {} current'.format(release_name))
         sudo('ln -sf current/libs/formplayer.jar formplayer.jar')
+        sudo('chmod 755 current/scripts/archive_dbs.sh')
         sudo('rm -r archive/ archive.zip')
 
 
@@ -80,7 +81,7 @@ def rollback_formplayer():
         if not console.confirm('Confirm rollback to "{}"'.format(rollback_build), default=False):
             utils.abort('Action aborted.')
 
-        sudo('ln -sf {build_dir}/{rollback} {build_dir}/current'.format(
+        sudo('ln -sfn {build_dir}/{rollback} {build_dir}/current'.format(
             build_dir=build_dir,
             rollback=rollback_build
         ))

--- a/fab/operations/formplayer.py
+++ b/fab/operations/formplayer.py
@@ -12,22 +12,41 @@ from ..const import ROLES_FORMPLAYER, FORMPLAYER_BUILD_DIR, DATE_FMT
 
 @roles(ROLES_FORMPLAYER)
 def build_formplayer(use_current_release=False):
+    """
+    the dir structure ends up looking like this:
+    ~/www/$ENV/current/fromplayer_build
+        formplayer__2017-08-23_16.16/
+            libs/formplayer.jar
+            scripts/archive_dbs.sh
+        current -> formplayer__2017-08-23_16.16
+        formplayer.jar -> current/libs/formplayer.jar
+
+    Thus the current artifacts will always be available at
+      ~/www/$ENV/current/fromplayer_build/formplayer.jar and
+      ~/www/$ENV/current/fromplayer_build/current/scripts/archive_dbs.sh
+    """
     code_dir = env.code_root if not use_current_release else env.code_current
     build_dir = os.path.join(code_dir, FORMPLAYER_BUILD_DIR)
     if not files.exists(build_dir):
         sudo('mkdir {}'.format(build_dir))
 
     if env.environment == 'staging':
-        jenkins_formplayer_build_url = 'https://jenkins.dimagi.com/job/formplayer-staging/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
+        jenkins_formplayer_build_url = 'https://jenkins.dimagi.com/job/formplayer-staging/lastSuccessfulBuild/artifact/*zip*/archive.zip'
     else:
-        jenkins_formplayer_build_url = 'https://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
+        jenkins_formplayer_build_url = 'https://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/*zip*/archive.zip'
 
     release_name = 'formplayer__{}'.format(datetime.datetime.utcnow().strftime(DATE_FMT))
-    sudo('wget -nv {} -O {}/{}'.format(jenkins_formplayer_build_url, build_dir, release_name))
-    sudo('ln -sf {build_dir}/{release_name} {build_dir}/formplayer.jar'.format(
-        build_dir=build_dir,
-        release_name=release_name
-    ))
+    with cd(build_dir):
+        sudo("wget -nv '{}' -O archive.zip".format(jenkins_formplayer_build_url))
+        # this will unzip into the build_dir
+        # (not because that's where archive.zip is but because of cd(build_dir) above)
+        # and will create a dir called archive because that's the name inside the zip
+        # (not because it's the name we chose for the zip file)
+        sudo("unzip archive.zip".format(build_dir, release_name))
+        sudo("mv archive/build {}".format(release_name))
+        sudo('ln -sf {} current'.format(release_name))
+        sudo('ln -sf current/libs/formplayer.jar formplayer.jar')
+        sudo('rm -r archive/ archive.zip')
 
 
 @roles(ROLES_FORMPLAYER)
@@ -46,9 +65,9 @@ def offline_build_formplayer():
 def rollback_formplayer():
     build_dir = os.path.join(env.code_current, FORMPLAYER_BUILD_DIR)
     with cd(build_dir):
-        current_build = sudo('readlink -f formplayer.jar').split('/')[-1]
+        current_build = sudo('readlink -f current').split('/')[-1]
 
-        previous_build_paths = sudo('find . -name "{}*"'.format('formplayer__')).strip()
+        previous_build_paths = sudo('find . -name "{}*" -type d'.format('formplayer__')).strip()
         if not previous_build_paths:
             utils.abort('No formplayer builds to rollback to.')
 
@@ -61,7 +80,7 @@ def rollback_formplayer():
         if not console.confirm('Confirm rollback to "{}"'.format(rollback_build), default=False):
             utils.abort('Action aborted.')
 
-        sudo('ln -sf {build_dir}/{rollback} {build_dir}/formplayer.jar'.format(
+        sudo('ln -sf {build_dir}/{rollback} {build_dir}/current'.format(
             build_dir=build_dir,
             rollback=rollback_build
         ))


### PR DESCRIPTION
to make it easier to include other build artifacts than just the jar.

I'm going to want to start having this formplayer archive.zip include a script called archive_dbs.sh that can be run in a cron job to gzip dbs that haven't gotten modified in a bit. See https://github.com/dimagi/formplayer/pull/452 related formplayer PRs for more info.

I tested both `fab staging deploy_formplayer` and `fab staging rollback_formplayer` and they both seem to work.

(Then running `./formplayer_build/current/scripts/archive_dbs.sh /opt/data/formplayer +1m` to gzip all dbs not modified in the last minute also seems to work.)