### PR TITLE
reduce number of queues for ucr_indicator_queue

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -57,7 +57,7 @@ enikshay:
         concurrency: 4
         max_tasks_per_child: 5
       ucr_indicator_queue:
-        concurrency: 16
+        concurrency: 8
       celery:
         concurrency: 8
         max_tasks_per_child: 5


### PR DESCRIPTION
postgres connections is maxing out when all 16 queues are running

@emord cc: @dannyroberts 