### PR TITLE
Add web2 back to webworkers

### DIFF
--- a/fab/inventory/icds
+++ b/fab/inventory/icds
@@ -217,6 +217,7 @@ web0
 [webworkers:children]
 web0
 web1
+web2
 web3
 web4
 web5


### PR DESCRIPTION
@dimagi/scale-team We originally did this because we were taking web2 to act as a celery worker for ucr rebuilds. At the moment we're turning off all ucr rebuild processes during the day anyways so going to add it back in