### PR TITLE
move formplayer onto machines with free mem

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -40,7 +40,7 @@ base:
 enikshay:
   environment: enikshay
   formplayer_memory: "7000m"
-  newrelic_javaagent: True
+  newrelic_javaagent: False
   celery_processes:
     '*':
       celery_periodic:

--- a/fab/inventory/enikshay
+++ b/fab/inventory/enikshay
@@ -126,8 +126,8 @@ datavol_device=/dev/mapper/consolidated-data
 es0
 
 [formplayer:children]
-formplayer0
-formplayer1
+proxy0
+kafka0
 
 [touchforms:children]
 web0

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command=java {% if newrelic_javaagent %}-javaagent:/home/cchq/www/{{ environment }}/newrelic/newrelic.jar{% endif %} -jar -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9999 -Xmx{{ formplayer_memory }} -XX:MaxPermSize=128m -Xss1024k {{ code_current}}/formplayer_build/formplayer.jar
+command=java {% if newrelic_javaagent %}-javaagent:/home/cchq/www/{{ environment }}/newrelic/newrelic.jar{% endif %} -jar -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 -Xmx{{ formplayer_memory }} -XX:MaxPermSize=128m -Xss1024k {{ code_current}}/formplayer_build/formplayer.jar
 user={{ sudo_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
formplayer0 => proxy0
formplayer1 => kafka0

My plan is to ansible deploy just formplayer to the new machines (without making proxy changes) and then to rsync the respective data directories. (Hopefully the proxy preserves hashing order like I think it does.) Then I'll deploy the proxy to smoothly switch over to the new machines, and then we can merge this