### PR TITLE
Add more work memory to pg0

### DIFF
--- a/fab/inventory/icds
+++ b/fab/inventory/icds
@@ -14,7 +14,7 @@ hot_standby_server='10.247.24.16'
 postgresql_max_connections=800
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=790
-pg_work_mem=32MB
+postgresql_work_mem=32MB
 hostname='pg0'
 
 [pg1]
@@ -28,7 +28,7 @@ hot_standby_server='10.247.24.17'
 postgresql_max_connections=800
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=790
-pg_work_mem=16MB
+postgresql_work_mem=16MB
 hostname='pg1'
 
 [pg2:vars]
@@ -40,7 +40,7 @@ hot_standby_server='10.247.24.28'
 postgresql_max_connections=400
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=390
-pg_work_mem=16MB
+postgresql_work_mem=16MB
 
 [pg3]
 10.247.24.23
@@ -54,7 +54,7 @@ hot_standby_server='10.247.24.29'
 postgresql_max_connections=800
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=790
-pg_work_mem=16MB
+postgresql_work_mem=16MB
 
 [web0]
 10.247.24.13

--- a/fab/inventory/icds
+++ b/fab/inventory/icds
@@ -14,6 +14,7 @@ hot_standby_server='10.247.24.16'
 postgresql_max_connections=800
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=790
+pg_work_mem=32MB
 hostname='pg0'
 
 [pg1]
@@ -27,6 +28,7 @@ hot_standby_server='10.247.24.17'
 postgresql_max_connections=800
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=790
+pg_work_mem=16MB
 hostname='pg1'
 
 [pg2:vars]
@@ -38,6 +40,7 @@ hot_standby_server='10.247.24.28'
 postgresql_max_connections=400
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=390
+pg_work_mem=16MB
 
 [pg3]
 10.247.24.23
@@ -51,6 +54,7 @@ hot_standby_server='10.247.24.29'
 postgresql_max_connections=800
 pgbouncer_max_connections=3500
 pgbouncer_default_pool=790
+pg_work_mem=16MB
 
 [web0]
 10.247.24.13


### PR DESCRIPTION
 @dimagi/scale-team thought?

I think upgrading this will help the aggregation script go much faster. I think it will need to be paired with a PR to remove this from icds_public.yml in ansible, but just looking for feedback right now.

http://pgtune.leopard.in.ua/ says we should use 64 MB for web apps and 300 MB for a data warehouse (which this kind of is)