### PR TITLE
Reduce ucr indicator worker concurrency on celery0

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -292,7 +292,7 @@ icds:
       async_restore_queue:
         concurrency: 4
       ucr_indicator_queue:
-        concurrency: 12
+        concurrency: 4
       flower: {}
     '10.247.24.31': # celery1
       ucr_indicator_queue:


### PR DESCRIPTION
Am reducing this to 4 from 12 and keeping the rest of the workers the same on this machine since this worker runs on a lot of other machines.

@emord 