### PR TITLE
Don't omit stack traces for null pointers

### DIFF
--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command=java {% if newrelic_javaagent %}-javaagent:/home/cchq/www/{{ environment }}/newrelic/newrelic.jar{% endif %} -jar -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 -Xmx{{ formplayer_memory }} -XX:MaxPermSize=128m -Xss1024k {{ code_current}}/formplayer_build/formplayer.jar
+command=java {% if newrelic_javaagent %}-javaagent:/home/cchq/www/{{ environment }}/newrelic/newrelic.jar{% endif %} -jar -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9998 -Xmx{{ formplayer_memory }} -XX:MaxPermSize=128m -XX:-OmitStackTraceInFastThrow -Xss1024k {{ code_current}}/formplayer_build/formplayer.jar
 user={{ sudo_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
Spring was "Optimizing" the complete stack traces out of all the `NullPointerException`s such as: https://sentry.io/dimagi/formplayer/issues/283441947/events/7590265370/

This will allegedly fix: 

https://dzone.com/articles/missing-stack-traces-repeated