### PR TITLE
adding web0 to celery list

### DIFF
--- a/fab/inventory/enikshay
+++ b/fab/inventory/enikshay
@@ -137,6 +137,7 @@ web0
 
 [celery:children]
 kafka0
+web0
 
 [rabbitmq:children]
 kafka0


### PR DESCRIPTION
@javierwilson @emord cc: @esoergel 
I think I left this off last time in https://github.com/dimagi/commcare-hq-deploy/pull/400