### PR TITLE
double enikshay UCR pillows

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -113,7 +113,7 @@ enikshay:
       GroupToUserPillow:
         num_processes: 1
       kafka-ucr-main:
-        num_processes: 2
+        num_processes: 4
       KafkaDomainPillow:
         num_processes: 1
       LedgerToElasticsearchPillow:
@@ -121,7 +121,7 @@ enikshay:
       CaseSearchToElasticsearchPillow:
         num_processes: 4
       kafka-ucr-static:
-        num_processes: 2
+        num_processes: 4
       SqlSMSPillow:
         num_processes: 1
       UnknownUsersPillow:


### PR DESCRIPTION
Running ```soft_delete_cases_with_no_person``` for prescriptions caused some UCR pillow backup:
https://app.datadoghq.com/dash/256236/change-feeds?live=false&page=0&is_auto=false&from_ts=1509477664295&to_ts=1509496962655&tile_size=m&tpl_var_env=enikshay&fullscreen=false

The next step is to run it for adherences, which will take several days to process.  Bumping the UCR pillow queues should help avoid backing up the queues during that time.  If doubling the number of pillows is not sufficient, then I can either redeploy with more pillows or pause the deletion process.

@sravfeyn @calellowitz @emord 