### PR TITLE
even more celery workers on the webworker

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -87,7 +87,7 @@ enikshay:
       flower: {}
     '172.25.2.6':
       ucr_indicator_queue:
-        concurrency: 4
+        concurrency: 8
   pillows:
     '*':
       AppDbChangeFeedPillow:


### PR DESCRIPTION
@emord @nickpell cc: @proteusvacuum 
memory and cpu utilization on the webworker is still pretty low and adding more celery processes seemed to have a good effect on async ucr queue