### PR TITLE
have fab use the port specified in the ansible inventory file

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -261,10 +261,19 @@ def read_inventory_file(filename):
     filename is a path to an ansible inventory file
 
     returns a mapping of group names ("webworker", "proxy", etc.)
-    to lists of hosts (ip addresses)
+    to lists of hostnames as listed in the inventory file.
+    ("Hostnames" can also be IP addresses.)
+    If the hostname in the file includes :<port>, that will be included here as well.
 
     """
-    return get_inventory(filename).get_group_dict()
+    inventory = get_inventory(filename)
+    port_map = {host.name: inventory.get_vars(hostname=host.name).get('ansible_port')
+                for host in inventory.get_hosts()}
+    return {group: [
+        '{}:{}'.format(host, port_map[host])
+        if port_map[host] is not None else host
+        for host in hosts
+    ] for group, hosts in get_inventory(filename).get_group_dict().items()}
 
 
 @task


### PR DESCRIPTION
Nicer solution for current workaround of putting

```
Host 196.207.230.171
     Port 1337
```

in our personal `~/.ssh/config`. The port is already in the ansible inventory file, so let's just pull it from there.