### PR TITLE
add empty standby sections for envs that don't have them

### DIFF
--- a/fab/inventory/softlayer
+++ b/fab/inventory/softlayer
@@ -148,3 +148,5 @@ couch1
 
 [control]
 10.162.36.196
+
+[pg_standby]

--- a/fab/inventory/staging
+++ b/fab/inventory/staging
@@ -47,3 +47,5 @@ hqriak01-staging.internal-va.commcarehq.org
 
 [control]
 control.internal-va.commcarehq.org
+
+[pg_standby]


### PR DESCRIPTION
fixes the following error on ansible deploy to staging (and I assume india)

`fatal: [hqdb1-staging.internal-va.commcarehq.org]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'pg_standby'"}`
