### PR TITLE
increase kafka-ucr-static pillows from 4 to 6

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -121,7 +121,7 @@ enikshay:
       CaseSearchToElasticsearchPillow:
         num_processes: 4
       kafka-ucr-static:
-        num_processes: 4
+        num_processes: 6
       SqlSMSPillow:
         num_processes: 1
       UnknownUsersPillow:


### PR DESCRIPTION
kafka-ucr-static pillow processing is slowly falling behind while I run a cleanup script.  Giving a small boost to the number of processors should keep it up to date.

web0.enikshay.in has available resources even during peaktime: https://app.datadoghq.com/dash/host/328223540?live=false&page=0&from_ts=1510610073872&to_ts=1511208191000&is_auto=false&tile_size=m

Current pillow processing since kicking off cleanup script: https://app.datadoghq.com/dash/256236/change-feeds?live=false&page=0&is_auto=false&from_ts=1511205745779&to_ts=1511208059591&tile_size=m&tpl_var_env=enikshay&fullscreen=false