### PR TITLE
Remove other clery queues

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -397,8 +397,8 @@ icds-new:
         concurrency: 1
       submission_reprocessing_queue:
         concurrency: 1
-      email_queue:
-        concurrency: 2
+      # email_queue:
+      #   concurrency: 2
     '10.247.164.41':
       ucr_queue:
         concurrency: 4
@@ -406,26 +406,26 @@ icds-new:
       background_queue:
         concurrency: 4
         max_tasks_per_child: 1
-      reminder_case_update_queue:
-        pooling: gevent
-        concurrency: 5
-        num_workers: 10
+      # reminder_case_update_queue:
+      #   pooling: gevent
+      #   concurrency: 5
+      #   num_workers: 10
     '10.247.164.42':
-      reminder_queue:
-        pooling: gevent
-        concurrency: 5
-        num_workers: 6
-      reminder_rule_queue:
-        concurrency: 1
-        max_tasks_per_child: 1
+      # reminder_queue:
+      #   pooling: gevent
+      #   concurrency: 5
+      #   num_workers: 6
+      # reminder_rule_queue:
+      #   concurrency: 1
+      #   max_tasks_per_child: 1
       saved_exports_queue:
         concurrency: 3
         max_tasks_per_child: 1
     '10.247.164.43':
-      sms_queue:
-        pooling: gevent
-        concurrency: 10
-        num_workers: 4
+      # sms_queue:
+      #   pooling: gevent
+      #   concurrency: 10
+      #   num_workers: 4
       async_restore_queue:
         concurrency: 4
       ucr_indicator_queue:
@@ -436,10 +436,10 @@ icds-new:
       background_queue:
         concurrency: 4
         max_tasks_per_child: 1
-      reminder_case_update_queue:
-        pooling: gevent
-        concurrency: 5
-        num_workers: 10
+      # reminder_case_update_queue:
+      #   pooling: gevent
+      #   concurrency: 5
+      #   num_workers: 10
     '10.247.164.31': # web0
       ucr_indicator_queue:
         concurrency: 3

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -137,8 +137,6 @@ enikshay:
       XFormToElasticsearchPillow:
         num_processes: 1
 
-
-
 softlayer:
   environment: softlayer
   formplayer_memory: "7000m"
@@ -390,15 +388,15 @@ icds-new:
       celery:
         concurrency: 8
         max_tasks_per_child: 5
-#      celery_periodic:
-#        concurrency: 4
-#        server_whitelist: 10.247.164.40
-      pillow_retry_queue:
-        concurrency: 1
-      submission_reprocessing_queue:
-        concurrency: 1
-      # email_queue:
-      #   concurrency: 2
+      # celery_periodic:
+      #   concurrency: 4
+      #   server_whitelist: 10.247.164.40
+      # pillow_retry_queue:
+      #   concurrency: 1
+      # submission_reprocessing_queue:
+      #   concurrency: 1
+      email_queue:
+        concurrency: 2
     '10.247.164.41':
       ucr_queue:
         concurrency: 4
@@ -406,18 +404,18 @@ icds-new:
       background_queue:
         concurrency: 4
         max_tasks_per_child: 1
-      # reminder_case_update_queue:
-      #   pooling: gevent
-      #   concurrency: 5
-      #   num_workers: 10
+      reminder_case_update_queue:
+        pooling: gevent
+        concurrency: 5
+        num_workers: 10
     '10.247.164.42':
       # reminder_queue:
       #   pooling: gevent
       #   concurrency: 5
       #   num_workers: 6
-      # reminder_rule_queue:
-      #   concurrency: 1
-      #   max_tasks_per_child: 1
+      reminder_rule_queue:
+        concurrency: 1
+        max_tasks_per_child: 1
       saved_exports_queue:
         concurrency: 3
         max_tasks_per_child: 1
@@ -436,10 +434,10 @@ icds-new:
       background_queue:
         concurrency: 4
         max_tasks_per_child: 1
-      # reminder_case_update_queue:
-      #   pooling: gevent
-      #   concurrency: 5
-      #   num_workers: 10
+      reminder_case_update_queue:
+        pooling: gevent
+        concurrency: 5
+        num_workers: 10
     '10.247.164.31': # web0
       ucr_indicator_queue:
         concurrency: 3


### PR DESCRIPTION
@gcapalbo thanks for catching https://github.com/dimagi/commcare-hq-deploy/pull/448

Your comment didn't totally match up with the queues we have defined. is there an easy way to stop celery beat from running?