### PR TITLE
Add back db0 instead of proxy0

### DIFF
--- a/fab/inventory/enikshay
+++ b/fab/inventory/enikshay
@@ -115,7 +115,7 @@ couch0
 db0
 
 [riakcs:children]
-proxy0
+db0
 es0
 couch0
 kafka0


### PR DESCRIPTION
change of plan
proxy0 was not ready to accept riak as of now due to missing encypted drive so moved in two steps