### PR TITLE
remove riak7

### DIFF
--- a/fab/inventory/icds-new
+++ b/fab/inventory/icds-new
@@ -373,14 +373,14 @@ partitions=["/dev/sdc1","/dev/sdd1"]
 datavol_device='/dev/mapper/consolidated-data'
 hostname='riak6'
 
-[riak7]
-10.247.164.55
-
-[riak7:vars]
-devices=["/dev/sdc","/dev/sdd"]
-partitions=["/dev/sdc1","/dev/sdd1"]
-datavol_device='/dev/mapper/consolidated-data'
-hostname='riak7'
+#[riak7]
+#10.247.164.55
+#
+#[riak7:vars]
+#devices=["/dev/sdc","/dev/sdd"]
+#partitions=["/dev/sdc1","/dev/sdd1"]
+#datavol_device='/dev/mapper/consolidated-data'
+#hostname='riak7'
 
 [celery0]
 10.247.164.40


### PR DESCRIPTION
since we removed riak from pg0.icds we only need
7 nodes and not 8. We can add this back after
the migration

@dimagi/scale-team 