### PR TITLE
Remove r.js check before running build_requirejs

### DIFF
--- a/fab/operations/staticfiles.py
+++ b/fab/operations/staticfiles.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from fabric.api import roles, parallel, sudo, env
 from fabric.context_managers import cd
-from fabric.contrib import files
 
 from fab.utils import bower_command
 
@@ -77,8 +76,7 @@ def collectstatic(use_current_release=False):
         sudo('{}/bin/python manage.py collectstatic --noinput -v 0'.format(venv))
         sudo('{}/bin/python manage.py fix_less_imports_collectstatic'.format(venv))
         sudo('{}/bin/python manage.py compilejsi18n'.format(venv))
-        if files.exists('{}/staticfiles/r.js'.format(env.code_current)):
-            sudo('rm -f tmp.sh resource_versions.py; {}/bin/python manage.py build_requirejs'.format(venv))
+        sudo('rm -f tmp.sh resource_versions.py; {}/bin/python manage.py build_requirejs'.format(venv))
 
 
 @parallel


### PR DESCRIPTION
@millerdev 

I suspect this is why the requirejs build step didn't run on the first deploy after requirejs was merged. That build step is running now; the various prod servers now have, and are serving, bundle.js files.

I'm not sure exactly why this would be a problem, since `collectstatic` should have made the `staticfiles/r.js` directory before this check runs, so it should have returned true even on that first deploy. But the bundle.js files weren't created on the first deploy, yet they have been created since then, without any other code changes or intervention, so I'm inclined to just remove this line, which was always meant to be temporary, and not dig any further.