### PR TITLE
Split pillows across servers

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -501,22 +501,36 @@ icds-new:
         num_processes: 1
     '10.247.164.39': # pillow2
       kafka-ucr-static-cases:
+        start_process: 0
         num_processes: 6
+        total_processes: 24
       CaseToElasticsearchPillow:
+        start_process: 0
         num_processes: 4
+        total_processes: 12
     '10.247.164.35': # pillow3
       kafka-ucr-static-cases:
+        start_process: 6
         num_processes: 6
+        total_processes: 24
       CaseToElasticsearchPillow:
+        start_process: 4
         num_processes: 4
+        total_processes: 12
     '10.247.164.33': # pillow4
       kafka-ucr-static-cases:
+        start_process: 12
         num_processes: 6
+        total_processes: 24
       CaseToElasticsearchPillow:
+        start_process: 8
         num_processes: 4
+        total_processes: 12
     '10.247.164.36': # pillow5
       kafka-ucr-static-cases:
+        start_process: 18
         num_processes: 6
+        total_processes: 24
       FormSubmissionMetadataTrackerPillow:
         num_processes: 4
     '10.247.164.34': # pillow6

--- a/fab/services/templates/supervisor_pillowtop.conf
+++ b/fab/services/templates/supervisor_pillowtop.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-pillowtop-{{ pillow_name }}-{{ process_num }}]
-command={{ virtualenv_current }}/bin/python {{ code_current }}/manage.py run_ptop {{ pillow_option }} --num-processes={{ num_processes }} --process-number={{ process_num }}
+command={{ virtualenv_current }}/bin/python {{ code_current }}/manage.py run_ptop {{ pillow_option }} --num-processes={{ total_processes }} --process-number={{ process_num }}
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1


### PR DESCRIPTION
@snopoke I think eventually we'll want to totally change the way this is configured and maybe deployed. Originally I wanted to keep this close to celery config, but that may not be the best way to configure these.

Decided against figuring these out progamatically because a) These are stored in dicts so we don't have a guarantee that they keep order when iterating (though we could sort it on IP or something), and b) the supervisor config creation is run on each server and they only have access to their own config https://github.com/dimagi/commcare-hq-deploy/blob/master/fab/utils.py#L45-L52

buddy @proteusvacuum 