### PR TITLE
Update celery4 to have 4 indicator queues

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -430,7 +430,7 @@ icds-new:
         concurrency: 4
     '10.247.164.44':
       ucr_indicator_queue:
-        concurrency: 16
+        concurrency: 4
       background_queue:
         concurrency: 4
         max_tasks_per_child: 1


### PR DESCRIPTION
celery4 only has 4 CPU

@czue 