### PR TITLE
 confirm environment time message show local time

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -263,9 +263,9 @@ def _confirm_environment_time(env_name, env_tz):
 
     message = (
         "Woah there bud! You're deploying '%s' during the day. "
-        "The time is currently %s.\n"
+        "The current local time is %s.\n"
         "ARE YOU DOING SOMETHING EXCEPTIONAL THAT WARRANTS THIS?"
-    ) % (env_name, d)
+    ) % (env_name, d.strftime("%-I:%M%p on %h. %d %Z"))
     if not console.confirm(message, default=False):
         utils.abort('Action aborted.')
 

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -263,8 +263,9 @@ def _confirm_environment_time(env_name, env_tz):
 
     message = (
         "Woah there bud! You're deploying '%s' during the day. "
+        "The time is currently %s.\n"
         "ARE YOU DOING SOMETHING EXCEPTIONAL THAT WARRANTS THIS?"
-    ) % env_name
+    ) % (env_name, d)
     if not console.confirm(message, default=False):
         utils.abort('Action aborted.')
 


### PR DESCRIPTION
Just adding a line like

```
The current local time is 1:12AM on Dec. 13 IST
```

to the confirm environment time feature in our fab file. Just a little something to contextualize the message.