### PR TITLE
re-enable periodic queue on icds

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -391,10 +391,10 @@ icds-new:
       celery_periodic:
          concurrency: 4
          server_whitelist: 10.247.164.40
-      # pillow_retry_queue:
-      #   concurrency: 1
-      # submission_reprocessing_queue:
-      #   concurrency: 1
+      pillow_retry_queue:
+         concurrency: 1
+      submission_reprocessing_queue:
+         concurrency: 1
       email_queue:
         concurrency: 2
     '10.247.164.41':

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -388,9 +388,9 @@ icds-new:
       celery:
         concurrency: 8
         max_tasks_per_child: 5
-      # celery_periodic:
-      #   concurrency: 4
-      #   server_whitelist: 10.247.164.40
+      celery_periodic:
+         concurrency: 4
+         server_whitelist: 10.247.164.40
       # pillow_retry_queue:
       #   concurrency: 1
       # submission_reprocessing_queue:


### PR DESCRIPTION
grepped for `CELERY_PERIODIC_QUEUE` and everything looks fine. we will run case update rules (seems fine) and attempt to send report emails (which will error, but I think that's ok?)

this will conflict with https://github.com/dimagi/commcare-hq-deploy/pull/481/ - I can update that PR once merged